### PR TITLE
Add non-usr-merged systemd-coredump to UMH whitelist

### DIFF
--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -45,6 +45,7 @@ static const char * const p_umh_global[] = {
    "/etc/acpi/events/RadioPower.sh",
    "/etc/acpi/wireless-rtl-ac-dc-power.sh",
    "/lib/systemd/systemd-cgroups-agent",
+   "/lib/systemd/systemd-coredump",
    "/sbin/bridge-stp",
    "/sbin/critical_overtemp",
    "/sbin/drbdadm",


### PR DESCRIPTION
Some distributions haven't merged /usr yet, so add the alternative
path for systemd-coredump.

Signed-off-by: John Helmert III <ajak@gentoo.org>

### Description
Add another path where systemd-coredump might be found to the UMH whitelist. This alternative path is already included for systemd-cgroups-agent, so adding the same for systemd-coredump should be reasonable.

### How Has This Been Tested?

With a vanilla lkrg-0.9.2, coredumps never appear and are blocked:

```
[  463.522397] [p_lkrg] Blocked usermodehelper execution of [/lib/systemd/systemd-coredump]
```

With my patch, coredumps are successful and accessible via systemd-coredump.