### PR TITLE
Fix build on latest CentOS Stream 8 and upcoming RHEL 8.6+

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -151,7 +151,8 @@
 
 static inline unsigned int p_get_task_state(struct task_struct *p_task) {
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) || \
+  (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(8,5))
    return READ_ONCE(p_task->__state);
 #elif defined(ACCESS_ONCE) && !defined(READ_ONCE)
    return ACCESS_ONCE(p_task->state);


### PR DESCRIPTION
Apparently, the rename of state to __state from Linux 5.14+ has just been back-ported to CentOS Stream 8 starting with 4.18.0-349.el8 and will be in RHEL 8.6+.

Fixes #141