### PR TITLE
CI: Various improvements, add more distributions to build test

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,4 +1,4 @@
-name: Multi-OS container builds
+name: docker build
 on: [push, pull_request]
 
 jobs:
@@ -12,12 +12,22 @@ jobs:
                       run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: centos:8
                       run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
-                    - image: quay.io/centos/centos:stream8
+                    - image: almalinux:8
                       run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: rockylinux:8
+                      run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: quay.io/centos/centos:stream8
+                      run: dnf install -y kernel-devel kernel gcc make elfutils-libelf-devel
+                    - image: quay.io/centos/centos:stream9
+                      run: dnf install -y --nobest kernel-devel-matched gcc make
                     - image: fedora:latest
                       run: dnf install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: alt:sisyphus
                       run: apt-get update; apt-get install -y kernel-headers-modules-un-def gcc make libelf-devel
+                    - image: opensuse/tumbleweed
+                      run: zypper -n install -y gcc make kernel-default-devel
+                    - image: opensuse/leap
+                      run: zypper -n install -y gcc make kernel-default-devel
 
         container:
             image: ${{ matrix.image }}
@@ -25,6 +35,7 @@ jobs:
 
         steps:
             - uses: actions/checkout@v1
+            - run: cat /etc/os-release
             - run: ${{ matrix.run }}
             - run: make -j$(nproc) KERNELRELEASE=$(cd /lib/modules; ls)
 

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,0 +1,49 @@
+name: docker cross build
+on: [push, pull_request]
+
+# Notes:
+#
+# - There is harmless warning:
+#
+#     "[Warning] The requested image's platform (linux/arm64/v8) does not
+#     match the detected host platform (linux/amd64) and no specific
+#     platform was requested"
+#
+#   It's hard to remove, perhaps, because we using 'build' and not 'buildx',
+#   which requires more setup.
+#
+# - git clean is not necessarily on GA, but added so it's easier to copy-paste
+#   Dockerfile for manual runs.
+
+jobs:
+    cross:
+        runs-on: ubuntu-20.04
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - image: arm64v8/ubuntu:impish
+                      packages: libelf-dev linux-headers-generic
+                    - image: arm32v7/alt:latest
+                      packages: elfutils kernel-headers-modules-std-def
+                    - image: i386/ubuntu:bionic
+                      packages: libelf-dev linux-headers-generic
+        steps:
+            - uses: docker/setup-qemu-action@v1
+            - uses: actions/checkout@v1
+            - name: Create Dockerfile
+              run: |
+                  cat <<EOF >Dockerfile
+                  FROM ${{ matrix.image }}
+                  RUN apt-get -y update && \
+                      apt-get install -y git file gcc make ${{ matrix.packages }}
+                  WORKDIR /src
+                  COPY . .
+                  RUN git clean -dxfq
+                  RUN gcc -v; cat /etc/os-release
+                  RUN make -j\$(nproc) KERNELRELEASE=\$(cd /lib/modules; ls)
+                  RUN file p_lkrg.ko
+                  EOF
+            - run: docker build .
+
+# vim: sw=4

--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -11,6 +11,7 @@ jobs:
                 release:
                     - focal
                     - hirsute
+                    - jammy
         steps:
             - uses: actions/checkout@v2
             - run: sudo apt-get update

--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -20,6 +20,7 @@ jobs:
               # able to build images properly.
               run: |
                   sudo python3 -m pip install git+https://github.com/systemd/mkosi.git
+                  sudo sed -i 's/linux-generic/linux-virtual/' /usr/local/lib/python*/dist-packages/mkosi/__init__.py
                   echo /usr/local/bin >> $GITHUB_PATH
 
             - name: Create bootable image using mkosi

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -19,13 +19,14 @@ jobs:
               # able to build images properly.
               run: |
                   sudo python3 -m pip install git+https://github.com/systemd/mkosi.git
+                  sudo sed -i 's/linux-generic/linux-virtual/' /usr/local/lib/python*/dist-packages/mkosi/__init__.py
                   echo /usr/local/bin >> $GITHUB_PATH
 
             - name: Download mainline kernel from Kernel PPA
               run: .github/workflows/ubuntu-kernel-daily.sh
 
             - name: Create bootable image using mkosi
-              run: sudo mkosi -r ${{ env.series }} -p '!linux-virtual' --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
+              run: sudo mkosi -r ${{ env.series }} --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
 
             - name: Boot image on qemu
               run: |

--- a/mkosi.build
+++ b/mkosi.build
@@ -5,6 +5,12 @@ KERNELRELEASE=$(ls -d /lib/modules/* | sort -V | tail -1)
 KERNELRELEASE=${KERNELRELEASE##/lib/modules/}
 export KERNELRELEASE
 
-banner build $KERNELRELEASE >&2
-make -j$(nproc)
+# No sysv banner on opensuse and centos9.
+type banner >/dev/null 2>&1 && banner build $KERNELRELEASE >&2
+
+# Allow manual run with make arguments, like 'clean'.
+make -j$(nproc) $@
+
+# Install if compiled.
+[ -e p_lkrg.ko ] && [ -v DESTDIR ] &&
 install -Dpm 644 p_lkrg.ko $DESTDIR/lib/modules/$KERNELRELEASE/extra/p_lkrg.ko

--- a/mkosi.default
+++ b/mkosi.default
@@ -26,7 +26,6 @@ BuildPackages=
 	diffutils
 	gcc
 	make
-	linux-base
 	linux-virtual
 Packages=
 	sysvbanner


### PR DESCRIPTION
* Do not download 200MB `linux-firmware` for mkosi tests. (I also created [issue in mkosi upstream](https://github.com/systemd/mkosi/issues/884).)
* Let `mkosi.build` be runnable manually.
* Build testing renamed from `Multi-OS container builds` to `docker build` (will be visible in Actions tab).
* More distributions added experimentally, but some can removed if not needed. (For example centos 8 clones, or openSUSE).
Also, there is compilations problems on centos9 and leap: https://github.com/vt-alt/lkrg/actions/runs/1703686921
