### PR TITLE
Fix build on opensuse/leap

### DIFF
--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -88,7 +88,8 @@ notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p
             ) &&
           p_tmp->addr
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) || \
-   (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 3))
+   (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 3)) || \
+   (defined(CONFIG_SUSE_PRODUCT_CODE) && CONFIG_SUSE_PRODUCT_CODE == 1)
           && p_tmp->opcode) {
 #else
           && p_tmp->detour) {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -106,7 +106,8 @@ int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs 
    if (!p_umh_allowed) {
 p_call_usermodehelper_entry_not_allowed:
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0) \
-    && !(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(8, 3))
+    && !(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(8, 3)) \
+    && !(defined(CONFIG_SUSE_PRODUCT_CODE) && CONFIG_SUSE_PRODUCT_CODE == 1)
       if (!strcmp("none",p_subproc->path) && p_subproc->file) {
          p_print_log(P_LKRG_ERR,
                 "<Exploit Detection> UMH is executing file from memory...\n");
@@ -138,7 +139,8 @@ p_call_usermodehelper_entry_not_allowed:
 
          }
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0) \
-    && !(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(8, 3))
+    && !(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(8, 3)) \
+    && !(defined(CONFIG_SUSE_PRODUCT_CODE) && CONFIG_SUSE_PRODUCT_CODE == 1)
       }
 #endif
    }


### PR DESCRIPTION
SUSE version `#if`s added to a set in a similar way as RHEL.

`CONFIG_SUSE_PRODUCT_CODE` `1` seems to be for Leap, `3` for Tumbleweed.