### PR TITLE
CI: Enable P_LKRG_JUMP_LABEL_STEXT_DEBUG in mainline test

### DIFF
--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -25,6 +25,11 @@ jobs:
             - name: Download mainline kernel from Kernel PPA
               run: .github/workflows/ubuntu-kernel-daily.sh
 
+            - name: Enable LKRG debugging options
+              run: |
+                  sed -i '/P_LKRG_JUMP_LABEL_STEXT_DEBUG/s/\/\///' src/modules/print_log/p_lkrg_log_level_shared.h
+                  git diff
+
             - name: Create bootable image using mkosi
               run: sudo mkosi -r ${{ env.series }} --cache=mkosi.cache --prepare-script=.github/workflows/dpkg-i.sh
 


### PR DESCRIPTION
As discussed in https://github.com/lkrg-org/lkrg/issues/137

>  It might be useful to always enable P_LKRG_JUMP_LABEL_STEXT_DEBUG on mainline build.

### How Has This Been Tested?
https://github.com/vt-alt/lkrg/runs/5013353445
