### PR TITLE
CI: Remove official Centos 8 docker build test

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,8 +10,6 @@ jobs:
                 include:
                     - image: centos:7
                       run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
-                    - image: centos:8
-                      run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: almalinux:8
                       run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: rockylinux:8


### PR DESCRIPTION
Centos 8 is not meant to be officially supported after 2021-12-31.
We already have Rocky Linux and AlmaLinux instead.

As discussed in https://github.com/lkrg-org/lkrg/pull/154#issuecomment-1026389127
