### PR TITLE
Add kernel diff (5.10) to export seccomp symbols

### DIFF
--- a/scripts/builtin/export_symbols_from_optimized_kernels.diff
+++ b/scripts/builtin/export_symbols_from_optimized_kernels.diff
@@ -1,0 +1,32 @@
+diff --git a/arch/x86/mm/pat/set_memory.c b/arch/x86/mm/pat/set_memory.c
+index 40baa90e74f4..c2cf7cea5846 100644
+--- a/arch/x86/mm/pat/set_memory.c
++++ b/arch/x86/mm/pat/set_memory.c
+@@ -1775,6 +1775,7 @@ static int change_page_attr_set_clr(unsigned long *addr, int numpages,
+ out:
+        return ret;
+ }
++EXPORT_SYMBOL(change_page_attr_set_clr);
+ 
+ static inline int change_page_attr_set(unsigned long *addr, int numpages,
+                                       pgprot_t mask, int array)
+diff --git a/kernel/seccomp.c b/kernel/seccomp.c
+index 305f0eca163e..fa0d391aef04 100644
+--- a/kernel/seccomp.c
++++ b/kernel/seccomp.c
+@@ -448,6 +448,7 @@ static void __put_seccomp_filter(struct seccomp_filter *orig)
+                seccomp_filter_free(freeme);
+        }
+ }
++EXPORT_SYMBOL(__put_seccomp_filter);
+ 
+ static void __seccomp_filter_release(struct seccomp_filter *orig)
+ {
+@@ -1705,6 +1706,8 @@ static long do_seccomp(unsigned int op, unsigned int flags,
+        }
+ }
+ 
++EXPORT_SYMBOL(do_seccomp);
++
+ SYSCALL_DEFINE3(seccomp, unsigned int, op, unsigned int, flags,
+


### PR DESCRIPTION
Custom kernels compiled with -O3 (or other optimization) appear to
break the runtime symbol resolution in LKRG, as per Adam's comment:
github.com/lkrg-org/lkrg/issues/135#issuecomment-1018693257

In order to maintain access to these symbols in the optimized O3
binary, explicit export annotations are required in the kernel at
build-time.

Implemented exports for do_seccomp, change_page_attr_set_clr, and
do_seccomp on 5.10.98-hardened. Extracted the resulting diff into
the scripts/builtin directory of this repo for application by users
who patch their own kernels already. This won't help people pulling
pre-built binaries out of repositories, but AUR users and similar
compile-on-demand setups should be able to add the diff to their
PKGBUILD/analogous build blueprint.

Testing:
  Arch Linux VM on 5.10.101 loading p_lkrg as a module succeeds.

### Description
Related to #158 and #135

### How Has This Been Tested?
Booted Arch Linux on 5.10.101 with this patch applied to the kernel sources and loaded the LKRG kernel module successfully:
```
[   49.980824] [p_lkrg] Loading LKRG...
[   64.531548] cfg80211: failed to load regulatory.db
[   64.532098] Freezing user space processes ... (elapsed 0.001 seconds) done.
[   64.533364] OOM killer disabled.
[   64.540020] [p_lkrg] LKRG can't enforce SELinux validation (CONFIG_GCC_PLUGIN_RANDSTRUCT detected)
[   64.755986] [p_lkrg] [kretprobe] register_kretprobe() for <ovl_create_or_link> failed! [err=-2]
[   64.756029] [p_lkrg] Can't hook 'ovl_create_or_link' function. This is expected if you are not using OverlayFS.
[   64.859440] [p_lkrg] [kretprobe] register_kretprobe() for <lookup_fast> failed! [err=-2]
[   64.859487] [p_lkrg] LKRG won't enforce pCFI validation on 'lookup_fast'
[   65.046324] [p_lkrg] LKRG initialized successfully!
[   65.046347] OOM killer enabled.
[   65.046348] Restarting tasks ... done.
```

