### PR TITLE
Improve x86 IDT dumping

### DIFF
--- a/src/modules/database/arch/x86/p_x86_metadata.c
+++ b/src/modules/database/arch/x86/p_x86_metadata.c
@@ -72,11 +72,10 @@ void p_dump_x86_metadata(void *_p_arg) {
 /*
  * IDTR register
  */
-#ifdef CONFIG_X86_64
-   unsigned char p_idtr[0xA];
-#else
-   unsigned char p_idtr[0x6];
-#endif
+   struct {
+      unsigned char dummy[2]; /* 2+ bytes for limit */
+      unsigned long base; /* 4 or 8 bytes */
+   } p_idtr;
 
    int p_curr_cpu = 0xFFFFFFFF;
 
@@ -101,34 +100,19 @@ void p_dump_x86_metadata(void *_p_arg) {
     /*
      * IDT...
      */
-#ifdef CONFIG_X86_64
-   __asm__("sidt   %0\n"
-           "movq   %3, %%rax\n"
-           "movq   %%rax,%1\n"
-           "movw   %4,%%ax\n"
-           "movw   %%ax,%2\n":"=m"(p_idtr),"=m"(p_arg[p_curr_cpu].p_base),"=m"(p_arg[p_curr_cpu].p_size)
-                             :"m"(p_idtr[2]),"m"(p_idtr[0])
-                             :"%rax");
-#else
-   __asm__("sidt   %0\n"
-           "movl   %3, %%eax\n"
-           "movl   %%eax,%1\n"
-           "movw   %4,%%ax\n"
-           "movw   %%ax,%2\n":"=m"(p_idtr),"=m"(p_arg[p_curr_cpu].p_base),"=m"(p_arg[p_curr_cpu].p_size)
-                             :"m"(p_idtr[2]),"m"(p_idtr[0])
-                             :"%eax");
-#endif
+   __asm__("sidt %0": "=m" (*((unsigned char *)&p_idtr.base - 2)), "=m" (p_idtr.base));
+   p_arg[p_curr_cpu].p_base = p_idtr.base;
 
    /*
     * On all x86 platforms there's defined maximum P_X86_MAX_IDT vectors.
     * We can hardcode that size here since some 'weird' modules might
-    * incorrectly set it to MAX_SHORT value.
+    * incorrectly set the limit e.g. to be higher than that.
     */
    p_arg[p_curr_cpu].p_size = P_X86_MAX_IDT;
 
 #if defined(CONFIG_X86_64) && defined(CONFIG_XEN_PVH)
-   if ((unsigned long)p_arg[p_curr_cpu].p_base >= 0xffff800000000000ULL &&
-       (unsigned long)p_arg[p_curr_cpu].p_base <= 0xffff87ffffffffffULL) {
+   if (p_arg[p_curr_cpu].p_base >= 0xffff800000000000ULL &&
+       p_arg[p_curr_cpu].p_base <= 0xffff87ffffffffffULL) {
       p_arg[p_curr_cpu].p_base = 0;
       p_arg[p_curr_cpu].p_size = 0;
    }

--- a/src/modules/database/arch/x86/p_x86_metadata.c
+++ b/src/modules/database/arch/x86/p_x86_metadata.c
@@ -126,8 +126,16 @@ void p_dump_x86_metadata(void *_p_arg) {
     */
    p_arg[p_curr_cpu].p_size = P_X86_MAX_IDT;
 
+#if defined(CONFIG_X86_64) && defined(CONFIG_XEN_PVH)
+   if ((unsigned long)p_arg[p_curr_cpu].p_base >= 0xffff800000000000ULL &&
+       (unsigned long)p_arg[p_curr_cpu].p_base <= 0xffff87ffffffffffULL) {
+      p_arg[p_curr_cpu].p_base = 0;
+      p_arg[p_curr_cpu].p_size = 0;
+   }
+#endif
+
    p_arg[p_curr_cpu].p_hash = p_lkrg_fast_hash((unsigned char *)p_arg[p_curr_cpu].p_base,
-                                               (unsigned int)sizeof(p_idt_descriptor) * P_X86_MAX_IDT);
+                                               sizeof(p_idt_descriptor) * p_arg[p_curr_cpu].p_size);
 
 // DEBUG
 #ifdef P_LKRG_DEBUG
@@ -135,6 +143,7 @@ void p_dump_x86_metadata(void *_p_arg) {
           "<p_dump_IDT_MSR> CPU:[%d] IDT => base[0x%lx] size[0x%x] hash[0x%llx]\n",
           p_arg[p_curr_cpu].p_cpu_id,p_arg[p_curr_cpu].p_base,p_arg[p_curr_cpu].p_size,p_arg[p_curr_cpu].p_hash);
 
+   if (p_arg[p_curr_cpu].p_size)
    do {
       p_idt_descriptor *p_test;
 

--- a/src/modules/database/arch/x86/p_x86_metadata.h
+++ b/src/modules/database/arch/x86/p_x86_metadata.h
@@ -70,10 +70,9 @@ typedef struct p_CPU_metadata_hash_mem {
    /*
     * IDT information
     */
-   long       p_base;            // IDT base from IDTR
-   short      p_size;            // IDT size from IDTR
-   uint64_t   p_hash;            // hash from entire IDT table:
-                                 //   p_base * P_X86_MAX_IDT
+   unsigned long p_base;         // IDT base from IDTR
+   uint16_t   p_size;            // LKRG's view of IDT size (0x100 or 0)
+   uint64_t   p_hash;            // hash from entire IDT (of p_size elements)
 
    /*
     * Now MSRs...


### PR DESCRIPTION
### Description
This fixes #159 and cleans up the code a little.

### How Has This Been Tested?
With these changes, LKRG in the old Xen PV setup appears to work fine. Previously, it crashed.
Further, all of out GitHub Actions tests passed (under my personal GitHub account).

However, I did not test on 32-bit x86, and I think we lack such tests in CI. Ideally, we'd also test that, because the cleanup commit replaces a 32-bit specific piece with a new shared one.