### PR TITLE
Fix build on post-5.17 kernels (avoid usage of mm_segment_t)

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -500,18 +500,16 @@ notrace void p_verify_addr_limit(struct p_ed_process *p_orig, struct task_struct
 #endif
 }
 
-notrace static inline void p_dump_addr_limit(mm_segment_t *p_addr_limit, struct task_struct *p_task) {
-
 #if defined(P_VERIFY_ADDR_LIMIT)
-
+notrace static inline void p_dump_addr_limit(mm_segment_t *p_addr_limit, struct task_struct *p_task) {
 #if defined(CONFIG_X86)
    p_addr_limit->seg =
 #elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
    *p_addr_limit =
 #endif
                        p_get_addr_limit(p_task);
-#endif
 }
+#endif
 
 notrace void p_update_ed_process(struct p_ed_process *p_source, struct task_struct *p_task, char p_stack) {
 


### PR DESCRIPTION
Fixes #170

### Description
This completes changes made earlier, which inadvertently kept using `mm_segment_t` even on kernels where we don't need that.

### How Has This Been Tested?
CI is all-green in my fork of the repo.