### PR TITLE
Workaround a CONFIG_KRETPROBE_ON_RETHOOK likely-bug in the kernel

### DIFF
--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -29,9 +29,11 @@
 
 char p_security_bprm_committing_creds_kretprobe_state = 0;
 
+notrace static int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) { return 0; }
+
 static struct kretprobe p_security_bprm_committing_creds_kretprobe = {
     .kp.symbol_name = "security_bprm_committing_creds",
-    .handler = NULL,
+    .handler = p_security_bprm_committing_creds_ret,
     .entry_handler = p_security_bprm_committing_creds_entry,
     .data_size = sizeof(struct p_security_bprm_committing_creds_data),
     /* Probe up to 40 instances concurrently. */


### PR DESCRIPTION
### Description
This works around the likely kernel bug discussed in #174.

### How Has This Been Tested?
A similar change has been CI-tested in a different branch, but let's wait for CI to be happy about this one.