### PR TITLE
debug: fix build with P_LKRG_STRONG_KPROBE_DEBUG

### DIFF
--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -73,7 +73,7 @@ notrace struct inode *p_get_inode_from_task(struct task_struct *p_arg) {
    return p_inode;
 }
 
-notrace int p_security_bprm_committed_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
 //   struct inode *p_inode;
    struct p_ed_process *p_tmp;

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -29,7 +29,7 @@
 
 char p_security_bprm_committing_creds_kretprobe_state = 0;
 
-notrace static int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) { return 0; }
+LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) { return 0; }
 
 static struct kretprobe p_security_bprm_committing_creds_kretprobe = {
     .kp.symbol_name = "security_bprm_committing_creds",
@@ -41,7 +41,7 @@ static struct kretprobe p_security_bprm_committing_creds_kretprobe = {
 };
 
 
-notrace int p_security_bprm_committing_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    unsigned long p_flags;

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
@@ -33,6 +33,7 @@ struct p_security_bprm_committing_creds_data {
 };
 
 int p_security_bprm_committing_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_security_bprm_committing_creds_hook(int p_isra);
 void p_uninstall_security_bprm_committing_creds_hook(void);
 

--- a/src/modules/print_log/p_lkrg_debug_log.c
+++ b/src/modules/print_log/p_lkrg_debug_log.c
@@ -127,7 +127,8 @@ static struct p_addr_name {
    P_LKRG_DEBUG_RULE_KPROBE(p_revert_creds),
    P_LKRG_DEBUG_RULE_KPROBE(p_override_creds),
    P_LKRG_DEBUG_RULE_KPROBE(security_bprm_committing_creds),
-   P_LKRG_DEBUG_RULE_KPROBE(security_bprm_committed_creds),
+   // Next function does not have matching entry one.
+   P_LKRG_DEBUG_RULE(p_security_bprm_committed_creds_ret),
    P_LKRG_DEBUG_RULE_KPROBE(p_sys_setresuid),
    P_LKRG_DEBUG_RULE_KPROBE(p_sys_keyctl),
    P_LKRG_DEBUG_RULE_KPROBE(p_key_change_session_keyring),

--- a/src/modules/print_log/p_lkrg_debug_log.c
+++ b/src/modules/print_log/p_lkrg_debug_log.c
@@ -126,7 +126,7 @@ static struct p_addr_name {
    P_LKRG_DEBUG_RULE_KPROBE(p_ovl_create_or_link),
    P_LKRG_DEBUG_RULE_KPROBE(p_revert_creds),
    P_LKRG_DEBUG_RULE_KPROBE(p_override_creds),
-   P_LKRG_DEBUG_RULE_KPROBE(security_bprm_committing_creds),
+   P_LKRG_DEBUG_RULE_KPROBE(p_security_bprm_committing_creds),
    // Next function does not have matching entry one.
    P_LKRG_DEBUG_RULE(p_security_bprm_committed_creds_ret),
    P_LKRG_DEBUG_RULE_KPROBE(p_sys_setresuid),

--- a/src/modules/print_log/p_lkrg_print_log.h
+++ b/src/modules/print_log/p_lkrg_print_log.h
@@ -194,8 +194,10 @@
 #ifdef P_LKRG_STRONG_KPROBE_DEBUG
  #define p_debug_kprobe_log(p_fmt, p_args...)                                            \
                   p_debug_log(P_LKRG_STRONG_DBG, p_fmt, ## p_args)
+ #define LKRG_DEBUG_TRACE
 #else
  #define p_debug_kprobe_log(p_fmt, p_args...)    ({ 0x0; })
+ #define LKRG_DEBUG_TRACE notrace
 #endif
 
 #define p_debug_log(p_level, p_fmt, p_args...)                                           \


### PR DESCRIPTION
### Description
In commit 9c5ef16cb51d51947c62e9116c6b52a3c3618bd0 we changed these
function to be untraceable. Respect that and remove them from
the list of traced functions.

This should address issue https://github.com/lkrg-org/lkrg/issues/176.

### How Has This Been Tested?
Building with debug flag and P_LKRG_STRONG_KPROBE_DEBUG enabled.