### PR TITLE
CI: Run boot-tests script with UMH test

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -38,6 +38,7 @@ jobs:
                   set timeout 300
                   expect "login: " {} default abort
                   set timeout 60
+                  expect "# " { send "/lkrg/.github/workflows/run-boot-tests.sh\r" } default abort
                   expect "# " { send "systemctl poweroff\r" } default abort
                   expect timeout abort eof { exit 0 }
                   EOF
@@ -49,6 +50,8 @@ jobs:
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
               run: "! egrep 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
+            - name: Check that boot-tests script finished successfully
+              run: grep 'run-boot-tests.sh - SUCCESS' boot.log
             - name: Check that boot.log contains shutdown sequence
               run: |
                   grep 'Reached target.*\(Power.Off\|Shutdown\)' boot.log

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -43,6 +43,7 @@ jobs:
                   set timeout 300
                   expect "login: " {} default abort
                   set timeout 60
+                  expect "# " { send "/lkrg/.github/workflows/run-boot-tests.sh\r" } default abort
                   expect "# " { send "systemctl poweroff\r" } default abort
                   expect timeout abort eof { exit 0 }
                   EOF
@@ -54,6 +55,8 @@ jobs:
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
               run: "! egrep 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
+            - name: Check that boot-tests script finished successfully
+              run: grep 'run-boot-tests.sh - SUCCESS' boot.log
             - name: Check that boot.log contains shutdown sequence
               run: |
                   grep 'Reached target.*Power.Off' boot.log

--- a/.github/workflows/run-boot-tests.sh
+++ b/.github/workflows/run-boot-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Run some tests
+#
+# Copyright (c) 2022 Vitaly Chikunov <vt@altlinux.org>.
+#
+
+set -eux -o pipefail
+
+# Trigger loading vhost_vsock module (using UMH call to modprobe).
+# Device numbers are from /lib/modules/*/modules.devname
+mknod /dev/test c 10 241
+true < /dev/test
+dmesg -T | grep 'Registered.*protocol family' | grep -w -e 'PF_VSOCK' -e '40'
+
+# Sleep (watchdog_thresh*2+1) seconds to let hard and soft lockup detectors to work.
+sleep 21
+
+# Failed tests will not output this line.
+echo "$0 - SUCCESS"

--- a/mkosi.build
+++ b/mkosi.build
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
-# mkosi.build - Compile and install module into DESTDIR.
+# mkosi.build - Compile and install compiled module and the source into DESTDIR.
 
 KERNELRELEASE=$(ls -d /lib/modules/* | sort -V | tail -1)
 KERNELRELEASE=${KERNELRELEASE##/lib/modules/}
@@ -13,4 +13,5 @@ make -j$(nproc) $@
 
 # Install if compiled.
 [ -e p_lkrg.ko ] && [ -v DESTDIR ] &&
-install -Dpm 644 p_lkrg.ko $DESTDIR/lib/modules/$KERNELRELEASE/extra/p_lkrg.ko
+install -Dpm 644 p_lkrg.ko $DESTDIR/lib/modules/$KERNELRELEASE/extra/p_lkrg.ko &&
+cp -av ./ $DESTDIR/lkrg/


### PR DESCRIPTION
Trigger loading of `vhost_vsock` module by the kernel, which uses UMH to call `modprobe`.

As a side effect copy (compiled) source tree into `/lkrg` of `mkosi` boot image. (This may be useful for manual testing.)

