### PR TITLE
CI: Use Docker to create bootable multi-arch images

### DIFF
--- a/.github/workflows/docker-boot.sh
+++ b/.github/workflows/docker-boot.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+PATH=$PATH:/sbin
+
+image=ubuntu:jammy
+qemu=qemu-system-x86_64
+opts="-bios bios.bin"
+console=ttyS0
+root=/dev/sda
+append=no_timer_check
+init=/lkrg/.github/workflows/run-boot-tests.sh
+kernel=linux-virtual
+[ -n "$1" ] && declare "$@"
+
+[ -v pkgs ] || pkgs="libelf-dev linux-headers-generic $kernel"
+
+echo "::group::Build image ($image)"
+set -exfu
+
+# Keep it in other directory since we will COPY . .
+td=$(mktemp -d)
+
+# Generate system and build in the Docker.
+docker build --tag test -f - . <<EOF
+# bionic is the latest Ubuntu with i386 support.
+FROM $image
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update -y && \
+    apt-get install -y \
+            gcc \
+            git \
+            make \
+            $pkgs
+WORKDIR /lkrg
+COPY . .
+RUN git clean -dxfq
+RUN DESTDIR= ./mkosi.build
+RUN depmod -a \$(cd /lib/modules; ls)
+EOF
+
+# Convert Docker container into QEMU image (first extract rootfs).
+docker rm test-container || :
+docker create --name test-container test
+mkdir -p $td/rootfs
+docker export test-container | tar x -C $td/rootfs
+docker rm test-container
+
+# Since inside of the Docker is qemu-user we need to do as much
+# as possible heavy operations outside of emulation.
+# Also, qemu-system will be run externally to avoid double emulation.
+
+qemu-img create -f raw $td/disk.img 8G
+mkfs.ext4 -q -d $td/rootfs -F $td/disk.img
+# Instead of hurling with the grub will boot using -kernel/-initrd.
+
+set +xe
+echo "::endgroup::"
+
+echo "::group::Boot image ($qemu)"
+# Output command in a handy way for a user.
+set -x
+set -- $qemu \
+	-m 2G \
+	-nographic \
+	-no-reboot \
+	-drive file=$td/disk.img,format=raw \
+	-kernel $(find $td/rootfs/boot -name vmlinuz-* -print -quit) \
+	-initrd $(find $td/rootfs/boot -name initrd.img-* -print -quit) \
+	${dtb+-dtb $(find $td/rootfs/lib/firmware -name $dtb)} \
+	$opts \
+	-append "console=$console root=$root $append panic=-1 oops=panic panic_on_warn softlockup_panic=1 init=$init"
+set +x
+# Different versions of QEMU and kernels are not reliable at powering off ARM32
+# machines, so seek help from expect(1) to terminate qemu when power off is
+# failed.
+expect - <<EOF -- "$@"
+set timeout 300
+spawn -noecho {*}\$argv
+expect {
+	"reboot: Power down" {
+		send_user "ABORT\n"
+		exit
+	} "Reboot failed -- System halted" {
+		send_user "ABORT\n"
+		exit
+	} timeout {
+		send_user "TIMEOUT\n"
+		exit
+	}
+}
+EOF
+rm -rf $td
+echo "::endgroup::"

--- a/.github/workflows/docker-boot.yml
+++ b/.github/workflows/docker-boot.yml
@@ -1,0 +1,63 @@
+name: docker arch boot
+on: [push, pull_request]
+
+jobs:
+    build:
+        runs-on: ubuntu-20.04
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - args: image=i386/ubuntu:bionic
+                            qemu=qemu-system-i386
+                      install: qemu-system-x86
+
+                    - args: image=arm64v8/ubuntu:impish
+                            opts="-M virt,gic-version=3 -cpu max"
+                            console=ttyAMA0
+                            root=/dev/vda
+                            qemu=qemu-system-aarch64
+                      install: qemu-system-arm
+
+                    # It's possible to use: opts="-M raspi2b" dtb=bcm2709-rpi-2-b.dtb root=/dev/mmcblk0
+                    # but since power-off is unreliable anyway (until QEMU 6.2) use simpler virt machine.
+                    - args: image=arm32v7/ubuntu:jammy
+                            opts="-M virt"
+                            console=ttyAMA0
+                            root=/dev/vda
+                            kernel="linux-raspi linux-modules-extra-raspi"
+                            qemu=qemu-system-arm
+                      install: qemu-system-arm
+
+        steps:
+            - uses: docker/setup-qemu-action@v1
+            - run: sudo apt-get update
+              # It's possible to update QEMU to (6.0) on focal (ubuntu-20.04) with
+              #   add-apt-repository ppa:canonical-server/server-backports
+              # but this is still not enough to boot & power-off raspi2b properly.
+            - run: sudo apt-get install -y qemu-utils e2fsprogs expect ${{ matrix.install }}
+
+            - uses: actions/checkout@v1
+            - name: Enable LKRG debugging options
+              run: |
+                  sed -i '/P_LKRG_JUMP_LABEL_STEXT_DEBUG/s/\/\///' src/modules/print_log/p_lkrg_log_level_shared.h
+                  git diff
+            - name: Build and boot test image
+              run: .github/workflows/docker-boot.sh ${{ matrix.args }} 2>&1 | tr -d '\r' | tee boot.log
+
+            - name: Check boot.log for 'LKRG initialized successfully'
+              run: |
+                  grep 'Linux version' boot.log
+                  grep 'LKRG initialized successfully' boot.log
+            - name: Check that boot.log does not contain problems
+              run:
+                  "! grep -v 'The requested image.s platform .* does not match the detected host platform' boot.log |
+                     grep -E 'Kernel panic|BUG:|WARNING:|Oops|Call Trace'"
+            - name: Check that boot-tests script finished successfully
+              run: grep 'run-boot-tests.sh - SUCCESS' boot.log
+            - name: Check that boot.log contains shutdown sequence
+              run: |
+                  grep 'sysrq: Power Off' boot.log
+                  grep 'reboot: Power down' boot.log
+
+# vim: sw=4

--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -49,7 +49,7 @@ jobs:
                   grep 'Linux version' boot.log
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
-              run: "! egrep 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
+              run: "! grep -E 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
             - name: Check that boot-tests script finished successfully
               run: grep 'run-boot-tests.sh - SUCCESS' boot.log
             - name: Check that boot.log contains shutdown sequence

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -54,7 +54,7 @@ jobs:
                   grep 'Linux version' boot.log
                   grep 'LKRG initialized successfully' boot.log
             - name: Check that boot.log does not contain problems
-              run: "! egrep 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
+              run: "! grep -E 'Kernel panic|BUG:|WARNING:|Oops|Call Trace' boot.log"
             - name: Check that boot-tests script finished successfully
               run: grep 'run-boot-tests.sh - SUCCESS' boot.log
             - name: Check that boot.log contains shutdown sequence

--- a/.github/workflows/run-boot-tests.sh
+++ b/.github/workflows/run-boot-tests.sh
@@ -8,6 +8,10 @@
 
 set -eux -o pipefail
 
+if [ ! -d /sys/module/p_lkrg ]; then
+	modprobe p_lkrg
+fi
+
 # Trigger loading vhost_vsock module (using UMH call to modprobe).
 # Device numbers are from /lib/modules/*/modules.devname
 mknod /dev/test c 10 241
@@ -19,3 +23,9 @@ sleep 21
 
 # Failed tests will not output this line.
 echo "$0 - SUCCESS"
+
+# If there is no systemd shutdown manually.
+if [ ! -d /run/systemd/system ]; then
+	echo o > /proc/sysrq-trigger
+	sleep 11
+fi

--- a/mkosi.build
+++ b/mkosi.build
@@ -14,4 +14,4 @@ make -j$(nproc) $@
 # Install if compiled.
 [ -e p_lkrg.ko ] && [ -v DESTDIR ] &&
 install -Dpm 644 p_lkrg.ko $DESTDIR/lib/modules/$KERNELRELEASE/extra/p_lkrg.ko &&
-cp -av ./ $DESTDIR/lkrg/
+cp -av ./ $DESTDIR/lkrg/ || :


### PR DESCRIPTION
Currently i386 and arm64v8. (I didn't find a way to create image for arm32v7 yet.)
x86_64 is just an example to prove it's working, since other arches are failing.
Perhaps we should delete x86_64 target.
And maybe we should delete arm64v8 either, it's slower than i386 and wasn't requested.