### PR TITLE
Reduce memory overhead generated by kmem_cache_create

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -367,7 +367,7 @@ static void p_ed_wq_valid_cache_zero(void *p_arg) {
 int p_ed_wq_valid_cache_init(void) {
 
    if ( (p_ed_wq_valid_cache = kmem_cache_create("p_ed_wq_valid_cache", sizeof(struct work_struct),
-                                                 0, SLAB_HWCACHE_ALIGN, p_ed_wq_valid_cache_zero)) == NULL) {
+                                                 0, P_LKRG_CACHE_FLAGS, p_ed_wq_valid_cache_zero)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for exploit detection validation error! :(\n");
       return -ENOMEM;
    }
@@ -1841,7 +1841,7 @@ static int p_ed_pcfi_cache_init(void) {
    int p_ret = P_LKRG_SUCCESS;
 
    if ( (p_ed_pcfi_cache = kmem_cache_create("p_ed_pcfi_cache", P_PCFI_STACK_BUF,
-                                            0, SLAB_HWCACHE_ALIGN, p_ed_pcfi_cache_zero)) == NULL) {
+                                            0, P_LKRG_CACHE_FLAGS, p_ed_pcfi_cache_zero)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for exploit detection pCFI error! :(\n");
       p_ret = -ENOMEM;
    }

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1951,7 +1951,8 @@ int p_ed_enforce_pcfi(struct task_struct *p_task, struct p_ed_process *p_orig, s
       unsigned long p_addr;
 
       for (unwind_start(&p_state, p_task, p_regs, NULL);
-           !unwind_done(&p_state); unwind_next_frame(&p_state)) {
+           !unwind_done(&p_state) && p_trace.nr_entries < p_trace.max_entries;
+           unwind_next_frame(&p_state)) {
          p_addr = unwind_get_return_address(&p_state);
          if (!p_addr)
             break;

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -232,9 +232,9 @@ struct p_seccomp {
 };
 
 #ifdef P_LKRG_TASK_OFF_DEBUG
- #define P_PCFI_STACK_BUF     (PAGE_SIZE >> 2)
+ #define P_PCFI_STACK_BUF     0x150
 #else
- #define P_PCFI_STACK_BUF     (PAGE_SIZE >> 1)
+ #define P_PCFI_STACK_BUF     0x200
 #endif
 
 #ifdef CONFIG_X86_64

--- a/src/modules/exploit_detection/p_rb_ed_trees/p_rb_ed_pids/p_rb_ed_pids_tree.c
+++ b/src/modules/exploit_detection/p_rb_ed_trees/p_rb_ed_pids/p_rb_ed_pids_tree.c
@@ -92,7 +92,7 @@ int p_init_rb_ed_pids(void) {
    }
 
    if ( (p_ed_pids_cache = kmem_cache_create("p_ed_pids", sizeof(struct p_ed_process),
-                                           0, SLAB_HWCACHE_ALIGN, p_ed_pids_cache_init)) == NULL) {
+                                           0, P_LKRG_CACHE_FLAGS, p_ed_pids_cache_init)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for ED PIDs error! :(\n");
       return -ENOMEM;
    }

--- a/src/modules/integrity_timer/p_integrity_timer.c
+++ b/src/modules/integrity_timer/p_integrity_timer.c
@@ -42,7 +42,7 @@ static void p_offload_cache_zero(void *p_arg) {
 int p_offload_cache_init(void) {
 
    if ( (p_offload_cache = kmem_cache_create("p_offload_cache", sizeof(struct work_struct),
-                                             0, SLAB_HWCACHE_ALIGN, p_offload_cache_zero)) == NULL) {
+                                             0, P_LKRG_CACHE_FLAGS, p_offload_cache_zero)) == NULL) {
       p_print_log(P_LKRG_ERR, "kmem_cache_create() for offloading error! :(\n");
       return -ENOMEM;
    }

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -104,6 +104,20 @@
 #endif
 
 /*
+ * Define kmem_cache_create() flags:
+ *  - LKRG has used to leverage SLAB_HWCACHE_ALIGN but memory overhead
+ *    may be too significant for LKRG's use cases
+ *  - Since the kernel 4.5+ we can use SLAB_ACCOUNT to make sure
+ *    that LKRG's caches are standalone
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,5,0)
+ #define P_LKRG_CACHE_FLAGS 0
+#else
+ #define P_LKRG_CACHE_FLAGS SLAB_ACCOUNT
+#endif
+
+
+/*
  * Some custom compilation of the kernel might aggresively inline
  * critical functions (from LKRG perspective). That's problematic
  * for the project. However, some of the problems *might* be solved


### PR DESCRIPTION
This commit brings a few important changes:
 - LKRG has used to leverage SLAB_HWCACHE_ALIGN but memory overhead
   may be too significant for LKRG's use cases
 - Since the kernel 4.5+ we can use SLAB_ACCOUNT to make sure that
   LKRG's caches are standalone
 - Modify the size of pCFI stack buffer cache to be smaller and
   decoupled from the PAGE_SIZE (there is no reason for that)

Additionally, this commit should help addressing #131

### Description
<!--- Describe your changes -->

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

