### PR TITLE
Enable variable length jump label backport for 5.15.40+, cleanup

### DIFF
--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -86,14 +86,8 @@ notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p
           p_tmp->rel_addr) {
 #else
       if ( (p_tmp->len == 5
-#if 0
- /*
-  * This will be needed when variable length JUMP_LABEL feature
-  * is backported to LTS or other active branches
-  */
- #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#if P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL
             || p_tmp->len == 2
- #endif
 #endif
             ) &&
           p_tmp->addr

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -36,10 +36,21 @@
 #ifndef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
 #define P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
 
+/*
+* This needs to be extended to other LTS or active branches if and
+* when they receive the variable length JUMP_LABEL feature backport
+*/
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || \
+    (LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 40))
+ #define P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL 1
+#else
+ #define P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL 0
+#endif
+
 #include <asm/text-patching.h>
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
- #if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
+ #if !P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL
 typedef struct _p_text_poke_loc {
     s32 rel_addr; /* addr := _stext + rel_addr */
     s32 rel32;


### PR DESCRIPTION
### Description
Rework the version checking code for the variable length JUMP_LABEL feature and extend this version check for Linux 5.15.40+.

It seems as of right now only the 5.15.x branch received this backport.

Closes: #192

### How Has This Been Tested?
Patch was applied to LKRG 0.9.3 and built against Linux 5.15.50. System was booted in this configuration, "LKRG initialized successfully!" message was observed, and no detected STEXT memory block hash mismatches were observed.
