### PR TITLE
CI: (mainline): Fix 'No space left on device' error

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -17,7 +17,7 @@ on: [push, pull_request]
 
 jobs:
     cross:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/docker-boot.yml
+++ b/.github/workflows/docker-boot.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
     mkosi-boot:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     mkosi-mainline:
         if: ${{ github.repository == 'lkrg-org/lkrg' || github.event_name != 'schedule' }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v2
             - run: sudo apt-get update

--- a/mkosi.default
+++ b/mkosi.default
@@ -19,7 +19,7 @@ BootProtocols=bios
 
 [Partitions]
 # 2G was not enough for build with mainline kernels installs.
-RootSize=3G
+RootSize=4G
 
 [Packages]
 BuildPackages=


### PR DESCRIPTION
### Description
Fix `mkosi boot (mainline)` build error, because of disk full. Increased `RootSize` +1G.
[ ALSO, while we at it, switched GA `ubuntu-20.04` -> `ubuntu-22.04`. Not tested and can undo if it fails here in this PR. But if it isn't why not switch to a shiny new env.  If failed I will make another PR later. ]

### How Has This Been Tested?
https://github.com/vt-alt/lkrg/actions/runs/2599988787

Fixes: https://github.com/lkrg-org/lkrg/issues/194