### PR TITLE
feat(scripts): support OpenRC init system

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+The following major changes have been made since LKRG 0.9.3:
+
+ *) OpenRC init system support
+
+
 The following major changes have been made between LKRG 0.9.2 and 0.9.3:
 
  *) Support new mainline kernels 5.17.x, 5.18-rc*, and hopefully beyond

--- a/LICENSE
+++ b/LICENSE
@@ -12,6 +12,9 @@ Copyright (c) 2021 Vitaly Chikunov
 debian/*
 Copyright (c) 2020-2021 Mikhail Morfikov
 
+scripts/bootup/openrc/*
+Copyright (c) 2022 Jakub 'mrl5' Kołodziejczak
+
 This version of LKRG is hereby being made available under the terms of the GNU
 General Public License version 2 as published by the Free Software Foundation.
 

--- a/README
+++ b/README
@@ -119,48 +119,80 @@ bootup and without the parameter override.
 Installation
 ------------
 
-If your Linux distribution uses systemd, you can install LKRG with:
+If your Linux distribution uses a supported init system (systemd or OpenRC),
+you can install LKRG with:
 
 	sudo make install
 
 while you're still in its top level source code directory.
 
-Run the following command to start the LKRG service just like it would be
-started on next system bootup:
+We don't in any way favor one init system over another, and would gladly add
+support for them as well if there's demand, or especially if we receive such
+contributions.  Meanwhile, on a distribution without a supported init system
+you can let "sudo make install" partially complete (up to the point where it
+finds you're not using a supported init system).
+
+Run the following command to start the LKRG service, for systemd:
 
 	sudo systemctl start lkrg
+
+for OpenRC:
+
+	sudo /etc/init.d/lkrg start
+
+for other:
+
+	sudo modprobe -v p_lkrg
+
+
+Autoload on bootup
+------------------
+
+In order to automatically load LKRG into the Linux kernel on each bootup run
+the following command, for systemd:
+
+	sudo systemctl enable lkrg
+
+for OpenRC:
+
+	sudo rc-update add lkrg boot
+
+for other:
+
+	sudo mkdir -p /etc/modules-load.d/ &&
+		echo p_lkrg | sudo tee /etc/modules-load.d/p_lkrg.conf
+
+Alternatively you can put the "modprobe p_lkrg" command into a system
+startup script.  Please note that ideally this command would run before sysctl
+files (especially /etc/sysctl.d/01-lkrg.conf) are processed, or otherwise the
+LKRG settings specified in those would not take effect.
+
+
+Uninstalling
+------------
 
 You can uninstall LKRG using "make" as well (still in the same directory):
 
 	sudo make uninstall
 
 You can also use the following command to temporarily stop the LKRG service
-without uninstalling it:
+without uninstalling it, for systemd:
 
 	sudo systemctl stop lkrg
 
-We don't in any way favor systemd over other init systems, and would gladly add
-support for those as well if there's demand, or especially if we receive such
-contributions.  Meanwhile, on a system without systemd you can let "sudo make
-install" partially complete (up to the point where it finds you're not using
-systemd) and then use:
+for OpenRC:
 
-	sudo modprobe p_lkrg
+	sudo /etc/init.d/lkrg stop
 
-to load the module.  You can also put the "modprobe p_lkrg" command into a
-system startup script.
+for other:
+
+	sudo modprobe -v -r p_lkrg
 
 
-Uninstalling and upgrading
---------------------------
+Upgrading
+---------
 
-Our suggested way to upgrade LKRG is to start by uninstalling the old version,
-which you can do with:
-
-	sudo make uninstall
-
-from the top level source code directory of that old version (doing so using
-the source code tree of the new version may or may not work correctly).
+Our suggested way to upgrade LKRG is to start by uninstalling the old version.
 
 You can then follow the Testing and Installation steps for the new version.
 
@@ -171,11 +203,12 @@ Recovery
 To account for the hopefully unlikely, but really unfortunate event that some
 incompatibility between the Linux kernel or other components of the system and
 LKRG isn't detected prior to LKRG installation, yet leads to system crash on
-bootup, we've included support for the "nolkrg" kernel parameter in the systemd
-unit file for LKRG.  Thus, if you've followed the above installation procedure
-for LKRG with systemd, you may disable LKRG by specifying "nolkrg" on the
-kernel command-line via your bootloader.  The system should then boot up
-without LKRG, and thus without triggering the problem, letting you fix it.
+bootup, we've included support for the "nolkrg" kernel parameter.  Thus, you
+may disable LKRG by specifying "nolkrg" on the kernel command-line via your
+bootloader.  The system should then boot up without LKRG, and thus without
+triggering the problem, letting you fix it.  You must be aware though, that you
+will not be able to manually load the LKRG module if the kernel was booted with
+this parameter.
 
 
 Module parameters

--- a/scripts/bootup/lkrg-bootup.sh
+++ b/scripts/bootup/lkrg-bootup.sh
@@ -7,6 +7,7 @@
 ##
 
 P_LKRG_SYSTEMD="scripts/bootup/systemd/lkrg-systemd.sh"
+P_LKRG_OPENRC="scripts/bootup/openrc/lkrg-openrc.sh"
 
 P_RED='\033[0;31m'
 P_GREEN='\033[0;32m'
@@ -20,7 +21,11 @@ case "`readlink -e /proc/1/exe`" in
 	/lib/systemd/systemd)
 		exec "$P_LKRG_SYSTEMD" "$@"
 		;;
+	/sbin/openrc-init | \
+	/sbin/init)
+		exec "$P_LKRG_OPENRC" "$@"
+		;;
 	*)
-		echo -e "  ${P_RED}[-] Unsupported init system: not systemd or not running as root?${P_NC}"
+		echo -e "  ${P_RED}[-] Unsupported init system or not running as root?${P_NC}"
 		;;
 esac

--- a/scripts/bootup/openrc/lkrg
+++ b/scripts/bootup/openrc/lkrg
@@ -1,0 +1,31 @@
+#!/sbin/openrc-run
+# Distributed under the terms of the GNU General Public License v2
+
+description="Linux Kernel Runtime Guard"
+command="/sbin/modprobe"
+command_args="-v p_lkrg"
+unload_command_args="-v -r p_lkrg"
+runlevel_command="/sbin/runlevel"
+grep_command="/bin/grep"
+
+depend() {
+	before sysctl modules
+}
+
+start() {
+	ebegin "Starting \"lkrg\" service"
+	$command $command_args
+	eend $?
+}
+
+stop() {
+	# for more info about runlevels (e.g. "S", "0", "1", "6") check: man 8 init
+	if $runlevel_command | $grep_command -q ' [S016]$'; then
+		ebegin "Stopping \"lkrg\" service without unloading \"p_lkrg\" module from the kernel"
+		eend $?
+	else
+		ebegin "Unloading \"p_lkrg\" module from the kernel"
+		$command $unload_command_args
+		eend $?
+	fi
+}

--- a/scripts/bootup/openrc/lkrg-openrc.sh
+++ b/scripts/bootup/openrc/lkrg-openrc.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# OpenRC installation script for LKRG (main branch)
+#
+# Author:
+#  - Adam 'pi3' Zabrocki (http://pi3.com.pl)
+#  - Jakub 'mrl5' Kołodziejczak (https://github.com/mrl5)
+##
+
+P_SYSCTL_DIR="/etc/sysctl.d"
+P_INITD_DIR="/etc/init.d"
+RUNLEVEL="boot"
+
+
+P_RED='\033[0;31m'
+P_GREEN='\033[0;32m'
+P_WHITE='\033[1;37m'
+P_YL='\033[1;33m'
+P_NC='\033[0m' # No Color
+
+echo -e "  ${P_GREEN}[+] ${P_WHITE}OpenRC detected${P_NC}"
+
+if [ "$1" == "install" ]; then
+	if [ -e "$P_INITD_DIR/lkrg" ]; then
+		echo -e "       ${P_RED}ERROR! ${P_YL}lkrg${P_RED} already exists under ${P_YL}$P_INITD_DIR${P_RED} directory${P_NC}"
+		exit 1
+	else
+		echo -e "       ${P_GREEN}Installing ${P_YL}lkrg${P_GREEN} file under ${P_YL}$P_INITD_DIR${P_GREEN} directory${P_NC}"
+		install -pm 755 -o root -g root scripts/bootup/openrc/lkrg "$P_INITD_DIR/lkrg"
+		echo -e "       ${P_GREEN}To start ${P_YL}lkrg${P_GREEN} please use: ${P_YL}/etc/init.d/lkrg start${P_NC}"
+		echo -e "       ${P_GREEN}To enable ${P_YL}lkrg${P_GREEN} on bootup please use: ${P_YL}rc-update add lkrg ${RUNLEVEL}${P_NC}"
+	fi
+	if [ -e "$P_SYSCTL_DIR/01-lkrg.conf" ]; then
+		echo -e "       ${P_YL}01-lkrg.conf${P_GREEN} is already installed, skipping${P_NC}"
+	else
+		echo -e "       ${P_GREEN}Installing ${P_YL}01-lkrg.conf${P_GREEN} file under ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
+		install -pm 644 -o root -g root scripts/bootup/lkrg.conf "$P_SYSCTL_DIR/01-lkrg.conf"
+	fi
+elif [ "$1" == "uninstall" ]; then
+	echo -e "       ${P_GREEN}Stopping ${P_YL}lkrg${P_NC}"
+	/etc/init.d/lkrg stop
+	echo -e "       ${P_GREEN}Disabling ${P_YL}lkrg${P_GREEN} on bootup${P_NC}"
+	rc-update del lkrg ${RUNLEVEL}
+	echo -e "       ${P_GREEN}Deleting ${P_YL}lkrg${P_GREEN} file from ${P_YL}$P_SYSTEMD_DIR${P_GREEN} directory${P_NC}"
+	rm "$P_INITD_DIR/lkrg"
+	if cmp -s "$P_SYSCTL_DIR/01-lkrg.conf" scripts/bootup/lkrg.conf; then
+		echo -e "       ${P_GREEN}Deleting unmodified ${P_YL}01-lkrg.conf${P_GREEN} file from ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
+		rm "$P_SYSCTL_DIR/01-lkrg.conf"
+	elif [ -e "$P_SYSCTL_DIR/01-lkrg.conf" ]; then
+		echo -e "       ${P_YL}$P_SYSCTL_DIR/01-lkrg.conf${P_GREEN} was modified, preserving it as ${P_YL}$P_SYSCTL_DIR/01-lkrg.conf.saved${P_NC}"
+		echo -e "       ${P_GREEN}If you do not need it anymore, delete it manually${P_NC}"
+		mv "$P_SYSCTL_DIR/01-lkrg.conf"{,.saved}
+	fi
+else
+	echo -e "      ${P_RED}ERROR! Unknown option!${P_NC}"
+	exit 1
+fi
+
+
+echo -e "  ${P_GREEN}[+] ${P_WHITE}Done!${P_NC}"


### PR DESCRIPTION
### Description
introduce OpenRC bootup scripts

### How Has This Been Tested?
I've tested it by running
```console
# make uninstall
# lsmod | grep lkrg
```
```console
# make install &&
  /etc/init.d/lkrg start &&
  lsmod | grep lkrg &&
  /etc/init.d/lkrg status &&
  rc-update add lkrg boot &&
  rc-update show | grep lkrg
```
```console
# make uninstall
# lsmod | grep lkrg
# /etc/init.d/lkrg status
# rc-update show | grep lkrg
```
on OpenRC system ([funtoo linux](https://www.funtoo.org))

**update**
after gathering requirements in [this comment](https://github.com/lkrg-org/lkrg/pull/197#issuecomment-1175588110) I've additionally run
```console
# runlevel
N 3
# /etc/init.d/lkrg stop
# lsmod | grep lkrg;  echo $?
1
# /etc/init.d/lkrg start
# lsmod | grep lkr
p_lkrg                221184  0
```

```console
# init 1
# lsmod | grep lkr
p_lkrg                221184  0
```

and ensured that `p_lkrg` module is not unloaded from the kernel on poweroff or reboot