### PR TITLE
Adapt copy-builtin.sh script for LKRG debug option

### DIFF
--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -23,6 +23,15 @@ config SECURITY_LKRG
           integrity validation and anti-exploitation functions.
 
 	  If you are unsure how to answer this question, answer M.
+
+config SECURITY_LKRG_DEBUG
+	bool "LKRG debug mode"
+	depends on SECURITY_LKRG
+	default n
+	help
+	  This builds LKRG - Linux Kernel Runtime Guard, in debug mode
+
+	  If you are unsure how to answer this question, answer N.
 EOC
 )
 
@@ -30,7 +39,13 @@ MAKEFILE=$(cat <<EOC
 # SPDX-License-Identifier: GPL-2.0-only
 
 obj-\$(CONFIG_SECURITY_LKRG) := p_lkrg.o
-$(awk '/^\$\(TARGET\)-objs/,/^$/' "$BASEDIR/../Makefile"|sed -e 's|src/||; s|$(TARGET)-objs|p_lkrg-objs|')
+ifeq (\$(SECURITY_LKRG_DEBUG), on)
+ccflags-m := -ggdb -DP_LKRG_DEBUG_BUILD -finstrument-functions
+ccflags-y := \${ccflags-m}
+p_lkrg-objs += modules/print_log/p_lkrg_debug_log.o
+endif
+
+$(grep '\.o' "$BASEDIR/../Makefile"|tail -n +3|grep -v '$(RM)'|sed -e 's|src/||; s|$(TARGET)-objs|p_lkrg-objs|g')
  
 EOC
 )


### PR DESCRIPTION
Changes to the Makefile enabling debug builds of LKRG resulted in
the copy-builtin script producing an errant Makefile inside the
target kernel tree.

Address this by creating a SECURITY_LKRG_DEBUG Kconfig option in
the Kconfig file and copy/update the relevant Makefile stanza into
the in-tree Makefile manually (vs extracting it from the source
Makefile and modifying in-flight).

Testing:
  Built in Arch chroot, verified prompt for new option and module
build in-tree.

### Description
<!--- Describe your changes -->

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

