### PR TITLE
CI: Remove EOL'ed Ubuntu releases

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -22,7 +22,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - image: arm64v8/ubuntu:impish
+                    - image: arm64v8/ubuntu:jammy
                       packages: libelf-dev linux-headers-generic
                     - image: arm32v7/alt:latest
                       packages: elfutils kernel-headers-modules-std-def

--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -11,7 +11,6 @@ jobs:
                 release:
                     - bionic
                     - focal
-                    - hirsute
                     - jammy
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
Impish is started to fail, because it's EOL'ed at July 14, 2022 (replaced with `jammy`). Hirsute is EOL'ed at January 20, 2022, but it started to fail only recently (removed).

Tested on GA in my fork.