### PR TITLE
Support variable length jump labels also for 5.10.133+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+The following major changes have been made since LKRG 0.9.4:
+ *) Support new longterm kernels 5.10.133+
+
+
 The following major changes have been made between LKRG 0.9.3 and 0.9.4:
 
  *) Support new longterm kernels 5.15.40+

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -36,12 +36,18 @@
 #ifndef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
 #define P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
 
+#include <asm/linkage.h> /* for ASM_RET */
+
 /*
-* This needs to be extended to other LTS or active branches if and
-* when they receive the variable length JUMP_LABEL feature backport
-*/
+ * This can be extended to other LTS or active branches if and when they
+ * receive the variable length JUMP_LABEL feature backport, although the
+ * addition of ASM_RET is part of the same change set and thus our check
+ * for it hopefully makes the specific kernel version checks redundant.
+ */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || \
-    (LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 40))
+    (LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 40)) || \
+    (LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 133)) || \
+    defined(ASM_RET)
  #define P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL 1
 #else
  #define P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL 0

--- a/src/modules/print_log/p_lkrg_print_log.h
+++ b/src/modules/print_log/p_lkrg_print_log.h
@@ -107,7 +107,7 @@
    int p_print_ret = 0;                                                                    \
                                                                                            \
    if (p_level == P_LOG_ALERT)                                                             \
-      p_print_ret = printk(KERN_CRIT    P_LKRG_SIGNATURE "ALERT: " p_fmt "\n", ## p_args); \
+      p_print_ret = printk(KERN_EMERG   P_LKRG_SIGNATURE "ALERT: " p_fmt "\n", ## p_args); \
    else if (P_CTRL(p_log_level) >= (p_level & 7))                                          \
    switch (p_level) {                                                                      \
    case P_LOG_ALIVE:                                                                       \


### PR DESCRIPTION
### Description
This takes care of the jump label change backport to 5.10.133+ and hopefully would also take care of potential backports of that change to even older branches. While at it, also increase severity of alerts from `CRIT` to `EMERG`.

### How Has This Been Tested?
CI on my fork shows 16 successful, 1 in progress. Also installed on an old system (without the variable length jump labels).