### PR TITLE
Overlay cleanup

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '33 3 * * 6'
 

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -298,7 +298,7 @@ static const struct p_functions_hooks {
      NULL,
      0
    },
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
    /* OverlayFS
     *
     * OverlayFS might not be installed in that system - it is not critical
@@ -306,27 +306,11 @@ static const struct p_functions_hooks {
     * in worst case, we might have FP. Continue...
     */
    {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
-     "ovl_dentry_is_whiteout",
-#else
-    /* Between the kernels 4.7 and 4.9, the 'ovl_dentry_is_whiteout' function does not exist */
-     "ovl_create_or_link",
-#endif
+     P_OVL_OVERRIDE_SYNC_FUNC,
      p_install_ovl_override_sync_hook,
      p_uninstall_ovl_override_sync_hook,
      0,
-     "Can't hook '"
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
-     "ovl_dentry_is_whiteout"
-#else
-    /* Between the kernels 4.7 and 4.9, the 'ovl_dentry_is_whiteout' function does not exist */
-     "ovl_create_or_link"
-#endif
-     "' function. This is expected when OverlayFS is not used.",
+     "Can't hook '" P_OVL_OVERRIDE_SYNC_FUNC "'. This is expected when OverlayFS is not used.",
      1
    },
 #endif
@@ -996,15 +980,13 @@ inline void p_validate_off_flag(struct p_ed_process *p_source, long p_val, int *
    p_ed_is_off_off(p_source, p_val, p_ret);
 }
 
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
 notrace int p_verify_ovl_override_sync(struct p_ed_process *p_source) {
 
    register unsigned long p_off = p_source->p_ed_task.p_off ^ p_global_off_cookie; // Decode
 
    p_validate_off_flag(p_source,p_off,NULL);   // Validate
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
+#if P_OVL_OVERRIDE_SYNC_MODE == 2
    return p_off == 3 * p_global_cnt_cookie;
 #else
    return p_off == 2 * p_global_cnt_cookie;

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -388,7 +388,7 @@ void p_ed_validate_off_flag_wrap(struct p_ed_process *p_source);
 void p_set_ed_process_override_on(struct p_ed_process *p_source);
 void p_set_ed_process_override_off(struct p_ed_process *p_source);
 void p_reset_ed_flags(struct p_ed_process *p_source);
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
 /* For OverlayFS */
 int p_verify_ovl_override_sync(struct p_ed_process *p_source);
 #endif

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
@@ -25,19 +25,12 @@
 
 #include "../../../../../../p_lkrg_main.h"
 
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
 
 char p_ovl_override_sync_kretprobe_state = 0;
 
 static struct kretprobe p_ovl_override_sync_kretprobe = {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
-    .kp.symbol_name = "ovl_dentry_is_whiteout",
-#else
-    /* Between the kernels 4.7 and 4.9, the 'ovl_dentry_is_whiteout' function does not exist */
-    .kp.symbol_name = "ovl_create_or_link",
-#endif
+    .kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC,
     .handler = p_ovl_override_sync_ret,
     .entry_handler = p_ovl_override_sync_entry,
     .data_size = sizeof(struct p_ovl_override_sync_data),
@@ -49,15 +42,7 @@ static struct kretprobe p_ovl_override_sync_kretprobe = {
 void p_reinit_ovl_override_sync_kretprobe(void) {
 
    memset(&p_ovl_override_sync_kretprobe,0x0,sizeof(struct kretprobe));
-   p_ovl_override_sync_kretprobe.kp.symbol_name = "ovl_override_sync";
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
-   p_ovl_override_sync_kretprobe.kp.symbol_name = "ovl_dentry_is_whiteout",
-#else
-    /* Between the kernels 4.7 and 4.9, the 'ovl_dentry_is_whiteout' function does not exist */
-   p_ovl_override_sync_kretprobe.kp.symbol_name = "ovl_create_or_link",
-#endif
+   p_ovl_override_sync_kretprobe.kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC;
    p_ovl_override_sync_kretprobe.handler = p_ovl_override_sync_ret;
    p_ovl_override_sync_kretprobe.entry_handler = p_ovl_override_sync_entry;
    p_ovl_override_sync_kretprobe.data_size = sizeof(struct p_ovl_override_sync_data);

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
@@ -23,12 +23,23 @@
  *
  */
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
-
 #ifndef P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H
 #define P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
+    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
+#define P_OVL_OVERRIDE_SYNC_MODE 2
+#define P_OVL_OVERRIDE_SYNC_FUNC "ovl_dentry_is_whiteout"
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
+/* Between 4.7 and 4.9, the 'ovl_dentry_is_whiteout' function does not exist */
+#define P_OVL_OVERRIDE_SYNC_MODE 1
+#define P_OVL_OVERRIDE_SYNC_FUNC "ovl_create_or_link"
+#else
+#define P_OVL_OVERRIDE_SYNC_MODE 0
+#endif
+
+#if P_OVL_OVERRIDE_SYNC_MODE
 
 /* per-instance private data */
 struct p_ovl_override_sync_data {

--- a/src/modules/kmod/p_kmod_notifier.c
+++ b/src/modules/kmod/p_kmod_notifier.c
@@ -249,7 +249,7 @@ p_module_event_notifier_activity_out:
 
 void p_verify_module_live(struct module *p_mod) {
 
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
    if (p_ovl_override_sync_kretprobe_state) {
       /* We do not need to do anything for now */
       return;
@@ -271,15 +271,7 @@ void p_verify_module_live(struct module *p_mod) {
       /* Try to install the hook */
       if (p_install_ovl_override_sync_hook(1)) {
          p_print_log(P_LOG_FAULT,
-                "OverlayFS is being loaded but LKRG can't hook '"
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0) || \
-    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 179) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 4))
-     "ovl_dentry_is_whiteout' function. "
-#else
-    /* Between the kernels 4.7 and 4.9, the 'ovl_dentry_is_whiteout' function does not exist */
-     "ovl_create_or_link' function. "
-#endif
+                "OverlayFS is being loaded but LKRG can't hook '" P_OVL_OVERRIDE_SYNC_FUNC "'. "
                 "It is very likely that LKRG will produce false positives. Please reload LKRG.");
       }
       /* Done */
@@ -292,7 +284,7 @@ void p_verify_module_live(struct module *p_mod) {
 
 void p_verify_module_going(struct module *p_mod) {
 
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
    if (!p_ovl_override_sync_kretprobe_state) {
       /* We do not need to do anything for now */
       return;

--- a/src/modules/print_log/p_lkrg_debug_log.c
+++ b/src/modules/print_log/p_lkrg_debug_log.c
@@ -123,7 +123,7 @@ static struct p_addr_name {
    P_LKRG_DEBUG_RULE_KPROBE(p_sys_setfsgid),
    P_LKRG_DEBUG_RULE_KPROBE(p_call_usermodehelper_exec),
    P_LKRG_DEBUG_RULE_KPROBE(p_set_current_groups),
-#if defined(P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H)
+#if P_OVL_OVERRIDE_SYNC_MODE
    P_LKRG_DEBUG_RULE_KPROBE(p_ovl_override_sync),
 #endif
    P_LKRG_DEBUG_RULE_KPROBE(p_revert_creds),


### PR DESCRIPTION
### Description

This simplifies the changes introduced in #217.

### How Has This Been Tested?

Built and loaded for/into a kernel where `ovl_dentry_is_whiteout` is expected. Saw the expected log messages (unchanged from before, except that the word `funcion` is dropped for consistency with other current LKRG messages) for the case of no `overlay` loaded yet. Did a `modprobe overlay`, found `ovl_dentry_is_whiteout` in `/sys/kernel/debug/kprobes/list`. Unloaded and reloaded LKRG (with `rmmod` and `insmod`), saw no messages about inability to hook `ovl_dentry_is_whiteout` that time, saw that it is hooked per `/sys/kernel/debug/kprobes/list`.

Did not test the logic beyond successful hooking of what's expected. That is, did not test the `off` count check code path in the hook.

Meanwhile, 12 successful and 6 in progress CI checks in my fork.