### PR TITLE
CI: mkosi: Do not assume grub is installed

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -12,10 +12,8 @@ Release=hirsute
 Bootable=yes
 # 'no_timer_check' is old workaround to intermittent apic kernel panic in qemu.
 KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1 ignore_loglevel
-# Simplest way of installing initrd is without unified kernel image,
-# which requires bios (grub) boot.
+# Separate initrd for possible debugging.
 WithUnifiedKernelImages=no
-BootProtocols=bios
 
 [Partitions]
 # 2G was not enough for build with mainline kernels installs.

--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -13,8 +13,10 @@ if test -x /usr/bin/dracut; then
 	depmod -a $KERNELRELEASE
 	# Install module into (and force load early in) initrd.
 	dracut --force --force-drivers lkrg /boot/initrd.img-$KERNELRELEASE $KERNELRELEASE
-	# Delete default cmdline which contains 'quiet splash' to see full boot log.
-	sed -i /GRUB_CMDLINE_LINUX_DEFAULT/d /etc/default/grub
-	update-grub
+	if [ -e /etc/default/grub ]; then
+		# Delete default cmdline which contains 'quiet splash' to see full boot log.
+		sed -i /GRUB_CMDLINE_LINUX_DEFAULT/d /etc/default/grub
+		update-grub
+	fi
 fi
 exit 0


### PR DESCRIPTION
mkosi' "--boot-protocols is deprecated and has no effect anymore", thus do not assume we will be booting using grub/bios.

Fixes: https://github.com/lkrg-org/lkrg/issues/227

[Not fully tested locally — will see GA report here.]