### PR TITLE
fix: umh - allow openrc cgroup release agent [#230]

### DIFF
--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -44,6 +44,7 @@ static const char * const p_umh_global[] = {
    "/bin/true",
    "/etc/acpi/events/RadioPower.sh",
    "/etc/acpi/wireless-rtl-ac-dc-power.sh",
+   "/lib/rc/sh/cgroup-release-agent.sh",
    "/lib/systemd/systemd-cgroups-agent",
    "/lib/systemd/systemd-coredump",
    "/sbin/bridge-stp",


### PR DESCRIPTION
closes #230

### Description
added [OpenRC's `/lib/rc/sh/cgroup-release-agent.sh`](https://github.com/OpenRC/openrc/blob/9b08de926b0ea2fd95d5d9f8cb3463eb3cd72d02/sh/cgroup-release-agent.sh.in) to [`p_umh_global[]`](https://github.com/lkrg-org/lkrg/blob/b56b8758afa23053dc62e0b469b1c12955cb94dc/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c#L39)

### How Has This Been Tested?
as a regular user I've:
made sure that bug is reproducable
```console
sudo /etc/init.d/cupsd restart
sudo /etc/init.d/cupsd restart
sudo dmesg | tail | grep 'LKRG: ALERT: BLOCK: UMH'
```

unloaded lkrg module and checked if it's there:
```console
sudo /etc/init.d/lkrg stop
lsmod | grep lkrg
```

tried to reproduce again
```console
sudo /etc/init.d/cupsd restart
sudo /etc/init.d/cupsd restart
sudo dmesg | tail | grep 'LKRG: ALERT: BLOCK: UMH'
```

compiled and installed `lkrg` that includes my changes
```console
make
sudo make install
```

made sure to replace already existing module by running
```console
sha256sum /lib/modules/5.18.16_p1-debian-sources/misc/lkrg.ko
sudo mv -v /lib/modules/5.18.16_p1-debian-sources/extra/lkrg.ko \
    /lib/modules/5.18.16_p1-debian-sources/misc/lkrg.ko
sha256sum /lib/modules/5.18.16_p1-debian-sources/misc/lkrg.ko
```

loaded new lkrg module
```console
sudo /etc/init.d/lkrg start
lsmod | grep lkrg
```

tried to reproduce again
```console
sudo /etc/init.d/cupsd restart
sudo /etc/init.d/cupsd restart
sudo dmesg | tail | grep 'LKRG: ALERT: BLOCK: UMH'
```