### PR TITLE
Clean up our use/wrapper of get_random_int()/get_random_long()

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -419,30 +419,6 @@ void p_debug_off_flag_override_off(struct p_ed_process *p_source, unsigned int p
 void p_debug_off_flag_override_on(struct p_ed_process *p_source, unsigned int p_id, struct pt_regs *p_regs);
 #endif
 
-#ifdef P_LKRG_CUSTOM_GET_RANDOM_LONG
-static DEFINE_PER_CPU(__u32 [MD5_DIGEST_WORDS], p_get_random_int_hash);
-
-static inline unsigned long get_random_long(void) {
-
-   __u32 *p_hash;
-   __u32 p_random_int_secret;
-   unsigned long p_ret;
-
-   if (arch_get_random_long(&p_ret))
-      return p_ret;
-
-   get_random_bytes(&p_random_int_secret, sizeof(p_random_int_secret));
-   p_hash = get_cpu_var(p_get_random_int_hash);
-
-   p_hash[0] += current->pid + jiffies + get_cycles();
-   md5_transform(p_hash, &p_random_int_secret);
-   p_ret = *(unsigned long *)p_hash;
-   put_cpu_var(p_get_random_int_hash);
-
-   return p_ret;
-}
-#endif
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
 #define p_force_sig(sig) force_sig((sig))
 #else

--- a/src/modules/notifiers/p_notifiers.h
+++ b/src/modules/notifiers/p_notifiers.h
@@ -33,7 +33,7 @@
 #define P_M_MORE_OFTEN_RATE       4294967       /*    0.1%   */
 #define P_S_MORE_OFTEN_RATE       2147483       /*    0.05%  */
 #define P_SS_MORE_OFTEN_RATE      429496        /*    0.01%  */
-#define P_M_SS_MORE_OFTEN_RATE    21474         /*    0.005% */
+#define P_M_SS_MORE_OFTEN_RATE    214748        /*    0.005% */
 #define P_S_SS_MORE_OFTEN_RATE    42949         /*    0.001% */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0)

--- a/src/modules/notifiers/p_notifiers.h
+++ b/src/modules/notifiers/p_notifiers.h
@@ -36,7 +36,11 @@
 #define P_M_SS_MORE_OFTEN_RATE    21474         /*    0.005% */
 #define P_S_SS_MORE_OFTEN_RATE    42949         /*    0.001% */
 
-#define P_CHECK_RANDOM(x) (get_random_int() <= x)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
+#define get_random_u32 get_random_int
+#endif
+
+#define P_CHECK_RANDOM(x) (get_random_u32() <= x)
 
 #define P_TRY_OFFLOAD_NOTIFIER(rate, where)                                \
 do {                                                                       \

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -73,9 +73,11 @@
 #if ( (LINUX_VERSION_CODE < KERNEL_VERSION(4,4,72)) && \
       (!(defined(RHEL_RELEASE_CODE)) || \
          RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 4)))
-#define P_LKRG_CUSTOM_GET_RANDOM_LONG
-/* We use md5_transform() in our custom get_random_long() */
-#include <linux/cryptohash.h>
+static inline unsigned long get_random_long(void) {
+   unsigned long p_ret;
+   get_random_bytes(&p_ret, sizeof(p_ret));
+   return p_ret;
+}
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)


### PR DESCRIPTION
This avoids use of the deprecated and now dropped `get_random_int` on Linux 4.11+ (#233), simplifies our `get_random_long` wrapper (#234), and fixes a typo in one of the notifiers' rates (changing its rate to hopefully what was intended).