### PR TITLE
CI: Re-enable AArch64 test, but without BTI

### DIFF
--- a/.github/workflows/docker-boot.yml
+++ b/.github/workflows/docker-boot.yml
@@ -11,13 +11,13 @@ jobs:
 #                    - args: image=i386/ubuntu:bionic
 #                            qemu=qemu-system-i386
 #                      install: qemu-system-x86
-#
-#                    - args: image=arm64v8/ubuntu:impish
-#                            opts="-M virt,gic-version=3 -cpu max"
-#                            console=ttyAMA0
-#                            root=/dev/vda
-#                            qemu=qemu-system-aarch64
-#                      install: qemu-system-arm
+
+                    - args: image=arm64v8/ubuntu:jammy
+                            opts="-M virt,gic-version=3 -cpu cortex-a57"
+                            console=ttyAMA0
+                            root=/dev/vda
+                            qemu=qemu-system-aarch64
+                      install: qemu-system-arm
 
                     # It's possible to use: opts="-M raspi2b" dtb=bcm2709-rpi-2-b.dtb root=/dev/mmcblk0
                     # but since power-off is unreliable anyway (until QEMU 6.2) use simpler virt machine.


### PR DESCRIPTION
### Description
1. Re-enable AArch64 test in our GitHub Actions. The test had been introduced in #181, but promptly disabled since it was failing all the time because of our lack of support of BTI in our hackish calls to non-exported kernel functions, tracked as #183.
2. Now we bypass that issue by specifying to QEMU `-cpu cortex-a57` instead of `-cpu max`, so that we do test on AArch64 but without BTI. I got `-cpu cortex-a57` from https://wiki.ubuntu.com/ARM64/QEMU
3. We also switch to testing on Ubuntu Jammy instead of Ubuntu Impish, as the latter had been EOL'ed and is no longer downloadable (at least by this test as previously configured).

### How Has This Been Tested?
The testing is described in some detail in comments I added today to #181. In short, this test now passes in my fork, whereas a different test with only re-enabling and switching to Jammy, but keeping `-cpu max`, fails with the BTI error like before. So all 3 of the changes here are required.