### PR TITLE
pINT: Make the real_cred check in p_cmp_tasks() unconditional

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1354,8 +1354,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
    }
 
    p_ret += p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x1);
-   if (p_ret)
-      p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x1);
+   p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x1);
 
    /* Namespaces */
    P_CMP_PTR(p_orig->p_ed_task.p_nsproxy, p_current->nsproxy, P_NS_ESCAPE "nsproxy")


### PR DESCRIPTION
Fixes #240

### Description
We were only performing a check of `real_cred` conditionally - only if we had already detected another discrepancy. @Adam-pi3 and I couldn't recall a reason for this limitation, so I tried removing the condition, and things seem fine.

### How Has This Been Tested?
Our CI tests are happy (except RHEL8, which currently can't be tested - pending another fix). Also, no issues when installed in an old Fedora VM with some light usage.