### PR TITLE
Add support for new RHEL8.6+ kernels

### DIFF
--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -72,14 +72,17 @@ notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p
 
    for (p_jl_batch_nr = 0; p_cnt < p_nr; p_cnt++) {
       p_tmp = (p_text_poke_loc *)&P_SYM(p_tp_vec)[p_jl_batch_nr*sizeof(p_text_poke_loc)];
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) || \
+    defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
       if ( (p_tmp->opcode == CALL_INSN_OPCODE
             || p_tmp->opcode == JMP32_INSN_OPCODE
             || p_tmp->opcode == INT3_INSN_OPCODE
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) || \
+    defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
             || p_tmp->opcode == RET_INSN_OPCODE
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0) || \
+    defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
             || p_tmp->opcode == JMP8_INSN_OPCODE
 #endif
             ) &&
@@ -101,7 +104,8 @@ notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p
 
 #endif
          p_jl_batch_addr[p_jl_batch_nr++] =
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) || \
+    defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
                   (unsigned long)p_tmp->rel_addr +
                   (unsigned long)p_db.kernel_stext.p_addr;
 #else

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -38,6 +38,10 @@
 
 #include <asm/linkage.h> /* for ASM_RET */
 
+#if defined(RHEL_RELEASE_CODE) && defined(DISP32_SIZE)
+ #define P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL 1
+#endif
+
 /*
  * This can be extended to other LTS or active branches if and when they
  * receive the variable length JUMP_LABEL feature backport, although the
@@ -55,8 +59,10 @@
 
 #include <asm/text-patching.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
- #if !P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0) || \
+    defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
+ #if !P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL || \
+     defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
 typedef struct _p_text_poke_loc {
     s32 rel_addr; /* addr := _stext + rel_addr */
     s32 rel32;


### PR DESCRIPTION
### Description
Starting from RHEL8.6 4.18.0-372.32.1.el8_6 kernel struct text_poke_loc is not exported and we need to correctly take this into account. Previous RHEL8.6 kernels did not hide this structure so we need to find some ways to disinguish them. We do it in this commit and it should fix #236

### How Has This Been Tested?
Tested against the following RHEL8.6 kernels:
- 4.18.0-372.26.1.el8_6.x86_64 (the newest kernel for RHEL 8.6)
- 4.18.0-372.32.1.el8_6.x86_64
- 4.18.0-372.9.1.el8.x86_64 (the oldest kernel for RHEL 8.6)
