### PR TITLE
kretprobes.maxactive should depend on number of cores

### DIFF
--- a/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.c
+++ b/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.c
@@ -36,8 +36,6 @@ static struct kretprobe p_ftrace_enable_sysctl_kretprobe = {
     .handler = p_ftrace_enable_sysctl_ret,
     .entry_handler = p_ftrace_enable_sysctl_entry,
     .data_size = sizeof(struct p_ftrace_enable_sysctl_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 notrace int p_ftrace_enable_sysctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
@@ -58,6 +56,7 @@ int p_install_ftrace_enable_sysctl_hook(void) {
 
    int p_tmp;
 
+   p_ftrace_enable_sysctl_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_ftrace_enable_sysctl_kretprobe)) != 0) {
       p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
                   p_ftrace_enable_sysctl_kretprobe.kp.symbol_name,

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -36,8 +36,6 @@ static struct kretprobe p_ftrace_modify_all_code_kretprobe = {
     .handler = p_ftrace_modify_all_code_ret,
     .entry_handler = p_ftrace_modify_all_code_entry,
     .data_size = sizeof(struct p_ftrace_modify_all_code_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*
@@ -214,6 +212,7 @@ int p_install_ftrace_modify_all_code_hook(void) {
    P_SYM_INIT(ftrace_rec_iter_next, struct ftrace_rec_iter *(*)(struct ftrace_rec_iter *))
    P_SYM_INIT(ftrace_rec_iter_record, struct dyn_ftrace *(*)(struct ftrace_rec_iter *))
 
+   p_ftrace_modify_all_code_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_ftrace_modify_all_code_kretprobe)) != 0) {
       p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
                   p_ftrace_modify_all_code_kretprobe.kp.symbol_name,

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -36,8 +36,6 @@ static struct kretprobe p_arch_jump_label_transform_kretprobe = {
     .handler = p_arch_jump_label_transform_ret,
     .entry_handler = p_arch_jump_label_transform_entry,
     .data_size = sizeof(struct p_arch_jump_label_transform_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 
@@ -202,6 +200,7 @@ int p_install_arch_jump_label_transform_hook(void) {
 
    p_lkrg_counter_lock_init(&p_jl_lock);
 
+   p_arch_jump_label_transform_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_arch_jump_label_transform_kretprobe)) != 0) {
       p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
                   p_arch_jump_label_transform_kretprobe.kp.symbol_name,

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -42,8 +42,6 @@ static struct kretprobe p_arch_jump_label_transform_apply_kretprobe = {
     .handler = p_arch_jump_label_transform_apply_ret,
     .entry_handler = p_arch_jump_label_transform_apply_entry,
     .data_size = sizeof(struct p_arch_jump_label_transform_apply_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 
@@ -258,6 +256,7 @@ int p_install_arch_jump_label_transform_apply_hook(void) {
                            (unsigned long)P_SYM(p_tp_vec),
                            (unsigned long)P_SYM(p_tp_vec_nr));
 
+   p_arch_jump_label_transform_apply_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_arch_jump_label_transform_apply_kretprobe)) != 0) {
       p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
                   p_arch_jump_label_transform_apply_kretprobe.kp.symbol_name,

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
@@ -30,8 +30,6 @@ static struct kretprobe p_arch_static_call_transform_kretprobe = {
     .handler = p_arch_static_call_transform_ret,
     .entry_handler = p_arch_static_call_transform_entry,
     .data_size = sizeof(struct p_arch_static_call_transform_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 static unsigned long p_tracepoint_tmp_text;
@@ -270,6 +268,7 @@ int p_install_arch_static_call_transform_hook(void) {
 
    p_lkrg_counter_lock_init(&p_static_call_spinlock);
 
+   p_arch_static_call_transform_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_arch_static_call_transform_kretprobe)) != 0) {
       p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
                   p_arch_static_call_transform_kretprobe.kp.symbol_name,

--- a/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
+++ b/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
@@ -32,8 +32,6 @@ static struct kretprobe p_switch_idt_kretprobe = {
     .handler = p_switch_idt_ret,
     .entry_handler = p_switch_idt_entry,
     .data_size = sizeof(struct p_switch_idt_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 
@@ -65,6 +63,7 @@ int p_install_switch_idt_hook(void) {
 
    int p_tmp;
 
+   p_switch_idt_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_switch_idt_kretprobe)) != 0) {
       p_print_log(P_LOG_ISSUE, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
                   p_switch_idt_kretprobe.kp.symbol_name,

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
@@ -32,8 +32,6 @@ static struct kretprobe p_x32_sys_keyctl_kretprobe = {
     .handler = p_x32_sys_keyctl_ret,
     .entry_handler = p_x32_sys_keyctl_entry,
     .data_size = sizeof(struct p_x32_sys_keyctl_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
@@ -28,8 +28,6 @@ static struct kretprobe p_cap_task_prctl_kretprobe = {
     .handler = p_cap_task_prctl_ret,
     .entry_handler = p_cap_task_prctl_entry,
     .data_size = sizeof(struct p_cap_task_prctl_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_capset_kretprobe = {
     .handler = p_sys_capset_ret,
     .entry_handler = p_sys_capset_entry,
     .data_size = sizeof(struct p_sys_capset_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
@@ -35,8 +35,6 @@ static struct kretprobe p_compat_sys_add_key_kretprobe = {
     .handler = p_compat_sys_add_key_ret,
     .entry_handler = p_compat_sys_add_key_entry,
     .data_size = sizeof(struct p_compat_sys_add_key_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
@@ -35,8 +35,6 @@ static struct kretprobe p_compat_sys_capset_kretprobe = {
     .handler = p_compat_sys_capset_ret,
     .entry_handler = p_compat_sys_capset_entry,
     .data_size = sizeof(struct p_compat_sys_capset_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
@@ -30,8 +30,6 @@ static struct kretprobe p_compat_sys_keyctl_kretprobe = {
     .handler = p_compat_sys_keyctl_ret,
     .entry_handler = p_compat_sys_keyctl_entry,
     .data_size = sizeof(struct p_compat_sys_keyctl_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
@@ -35,8 +35,6 @@ static struct kretprobe p_compat_sys_request_key_kretprobe = {
     .handler = p_compat_sys_request_key_ret,
     .entry_handler = p_compat_sys_request_key_entry,
     .data_size = sizeof(struct p_compat_sys_request_key_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -34,8 +34,6 @@ static struct kretprobe p_security_bprm_committed_creds_kretprobe = {
     .handler = p_security_bprm_committed_creds_ret,
     .entry_handler = NULL,
     .data_size = sizeof(struct p_security_bprm_committed_creds_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -36,8 +36,6 @@ static struct kretprobe p_security_bprm_committing_creds_kretprobe = {
     .handler = p_security_bprm_committing_creds_ret,
     .entry_handler = p_security_bprm_committing_creds_entry,
     .data_size = sizeof(struct p_security_bprm_committing_creds_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
@@ -28,8 +28,6 @@ static struct kretprobe p_key_change_session_keyring_kretprobe = {
     .handler = p_key_change_session_keyring_ret,
     .entry_handler = p_key_change_session_keyring_entry,
     .data_size = sizeof(struct p_key_change_session_keyring_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_add_key_kretprobe = {
     .handler = p_sys_add_key_ret,
     .entry_handler = p_sys_add_key_entry,
     .data_size = sizeof(struct p_sys_add_key_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_keyctl_kretprobe = {
     .handler = p_sys_keyctl_ret,
     .entry_handler = p_sys_keyctl_entry,
     .data_size = sizeof(struct p_sys_keyctl_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_request_key_kretprobe = {
     .handler = p_sys_request_key_ret,
     .entry_handler = p_sys_request_key_entry,
     .data_size = sizeof(struct p_sys_request_key_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
@@ -44,7 +44,7 @@ void p_reinit_ovl_override_sync_kretprobe(void) {
    p_ovl_override_sync_kretprobe.handler = p_ovl_override_sync_ret;
    p_ovl_override_sync_kretprobe.entry_handler = p_ovl_override_sync_entry;
    p_ovl_override_sync_kretprobe.data_size = sizeof(struct p_ovl_override_sync_data);
-   p_ovl_override_sync_kretprobe.maxactive = 40;
+   p_ovl_override_sync_kretprobe.maxactive = p_get_kprobe_maxactive();
 }
 
 int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
@@ -34,8 +34,6 @@ static struct kretprobe p_ovl_override_sync_kretprobe = {
     .handler = p_ovl_override_sync_ret,
     .entry_handler = p_ovl_override_sync_entry,
     .data_size = sizeof(struct p_ovl_override_sync_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -29,8 +29,6 @@ static struct kretprobe p_override_creds_kretprobe = {
     .handler = p_override_creds_ret,
     .entry_handler = p_override_creds_entry,
     .data_size = sizeof(struct p_override_creds_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -28,8 +28,6 @@ static struct kretprobe p_revert_creds_kretprobe = {
     .handler = p_revert_creds_ret,
     .entry_handler = p_revert_creds_entry,
     .data_size = sizeof(struct p_revert_creds_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -28,8 +28,6 @@ static struct kretprobe p_pcfi___queue_work_kretprobe = {
     .handler = p_pcfi___queue_work_ret,
     .entry_handler = p_pcfi___queue_work_entry,
     .data_size = sizeof(struct p_pcfi___queue_work_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
@@ -28,8 +28,6 @@ static struct kretprobe p_pcfi_lookup_fast_kretprobe = {
     .handler = p_pcfi_lookup_fast_ret,
     .entry_handler = p_pcfi_lookup_fast_entry,
     .data_size = sizeof(struct p_pcfi_lookup_fast_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
@@ -28,8 +28,6 @@ static struct kretprobe p_pcfi_mark_inode_dirty_kretprobe = {
     .handler = p_pcfi_mark_inode_dirty_ret,
     .entry_handler = p_pcfi_mark_inode_dirty_entry,
     .data_size = sizeof(struct p_pcfi_mark_inode_dirty_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
@@ -28,8 +28,6 @@ static struct kretprobe p_pcfi_schedule_kretprobe = {
     .handler = p_pcfi_schedule_ret,
     .entry_handler = p_pcfi_schedule_entry,
     .data_size = sizeof(struct p_pcfi_schedule_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -32,8 +32,6 @@ static struct kretprobe p_call_usermodehelper_kretprobe = {
     .handler = p_call_usermodehelper_ret,
     .entry_handler = p_call_usermodehelper_entry,
     .data_size = sizeof(struct p_call_usermodehelper_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 static const char * const p_umh_global[] = {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
@@ -29,8 +29,6 @@ static struct kretprobe p_call_usermodehelper_exec_kretprobe = {
     .handler = p_call_usermodehelper_exec_ret,
     .entry_handler = p_call_usermodehelper_exec_entry,
     .data_size = sizeof(struct p_call_usermodehelper_exec_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
@@ -28,8 +28,6 @@ static struct kretprobe p_capable_kretprobe = {
     .handler = p_capable_ret,
     .entry_handler = p_capable_entry,
     .data_size = sizeof(struct p_capable_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
@@ -29,8 +29,6 @@ static struct kretprobe p_do_exit_kretprobe = {
     .handler = p_do_exit_ret,
     .entry_handler = p_do_exit_entry,
     .data_size = sizeof(struct p_do_exit_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
@@ -46,8 +46,6 @@ static struct kretprobe p_generic_permission_kretprobe = {
     .handler = p_generic_permission_ret,
     .entry_handler = p_generic_permission_entry,
     .data_size = sizeof(struct p_generic_permission_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_install.c
+++ b/src/modules/exploit_detection/syscalls/p_install.c
@@ -21,7 +21,7 @@
 #include "../../../p_lkrg_main.h"
 
 // to setup kretprobes maxactive
-static int p_get_kprobe_maxactive(void) {
+int p_get_kprobe_maxactive(void) {
 
 /*
  * Linux default is up to max(10, 2*num_possible_cpus()) so far.

--- a/src/modules/exploit_detection/syscalls/p_install.c
+++ b/src/modules/exploit_detection/syscalls/p_install.c
@@ -20,12 +20,23 @@
 
 #include "../../../p_lkrg_main.h"
 
+// to setup kretprobes maxactive
+static int p_get_kprobe_maxactive(void) {
+
+/*
+ * Linux default is up to max(10, 2*num_possible_cpus()) so far.
+ * LKRG old default was 40.  Let's use max of these all.
+ */
+   return max_t(unsigned int, 40, 2*num_possible_cpus());
+}
+
 int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
 
    int p_ret;
    const char *p_name = kretprobe->kp.symbol_name;
    struct p_isra_argument p_isra_arg;
 
+   kretprobe->maxactive = p_get_kprobe_maxactive();
    if ( (p_ret = register_kretprobe(kretprobe)) < 0) {
       if (p_isra && p_ret == -22) {
          p_print_log(P_LOG_ISSUE, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",

--- a/src/modules/exploit_detection/syscalls/p_install.h
+++ b/src/modules/exploit_detection/syscalls/p_install.h
@@ -21,6 +21,7 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_INSTALL_H
 #define P_LKRG_EXPLOIT_DETECTION_INSTALL_H
 
+int p_get_kprobe_maxactive(void);
 
 int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra);
 void p_uninstall_hook(struct kretprobe *kretprobe, char *state);

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
@@ -29,8 +29,6 @@ static struct kretprobe p_scm_send_kretprobe = {
     .handler = p_scm_send_ret,
     .entry_handler = p_scm_send_entry,
     .data_size = sizeof(struct p_scm_send_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
@@ -32,8 +32,6 @@ static struct kretprobe p_seccomp_kretprobe = {
     .handler = p_seccomp_ret,
     .entry_handler = p_seccomp_entry,
     .data_size = sizeof(struct p_seccomp_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
@@ -28,8 +28,6 @@ static struct kretprobe p_security_ptrace_access_kretprobe = {
     .handler = p_security_ptrace_access_ret,
     .entry_handler = p_security_ptrace_access_entry,
     .data_size = sizeof(struct p_security_ptrace_access_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
@@ -30,8 +30,6 @@ static struct kretprobe p_sel_write_enforce_kretprobe = {
     .handler = p_sel_write_enforce_ret,
     .entry_handler = p_sel_write_enforce_entry,
     .data_size = sizeof(struct p_sel_write_enforce_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
@@ -28,8 +28,6 @@ static struct kretprobe p_set_current_groups_kretprobe = {
     .handler = p_set_current_groups_ret,
     .entry_handler = p_set_current_groups_entry,
     .data_size = sizeof(struct p_set_current_groups_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setfsgid_kretprobe = {
     .handler = p_sys_setfsgid_ret,
     .entry_handler = p_sys_setfsgid_entry,
     .data_size = sizeof(struct p_sys_setfsgid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setfsuid_kretprobe = {
     .handler = p_sys_setfsuid_ret,
     .entry_handler = p_sys_setfsuid_entry,
     .data_size = sizeof(struct p_sys_setfsuid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setgid_kretprobe = {
     .handler = p_sys_setgid_ret,
     .entry_handler = p_sys_setgid_entry,
     .data_size = sizeof(struct p_sys_setgid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setns_kretprobe = {
     .handler = p_sys_setns_ret,
     .entry_handler = p_sys_setns_entry,
     .data_size = sizeof(struct p_sys_setns_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setregid_kretprobe = {
     .handler = p_sys_setregid_ret,
     .entry_handler = p_sys_setregid_entry,
     .data_size = sizeof(struct p_sys_setregid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setresgid_kretprobe = {
     .handler = p_sys_setresgid_ret,
     .entry_handler = p_sys_setresgid_entry,
     .data_size = sizeof(struct p_sys_setresgid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setresuid_kretprobe = {
     .handler = p_sys_setresuid_ret,
     .entry_handler = p_sys_setresuid_entry,
     .data_size = sizeof(struct p_sys_setresuid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setreuid_kretprobe = {
     .handler = p_sys_setreuid_ret,
     .entry_handler = p_sys_setreuid_entry,
     .data_size = sizeof(struct p_sys_setreuid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
@@ -28,8 +28,6 @@ static struct kretprobe p_sys_setuid_kretprobe = {
     .handler = p_sys_setuid_ret,
     .entry_handler = p_sys_setuid_entry,
     .data_size = sizeof(struct p_sys_setuid_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
@@ -32,8 +32,6 @@ static struct kretprobe p_sys_unshare_kretprobe = {
     .handler = p_sys_unshare_ret,
     .entry_handler = p_sys_unshare_entry,
     .data_size = sizeof(struct p_sys_unshare_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -29,8 +29,6 @@ static struct kretprobe p_wake_up_new_task_kretprobe = {
     .handler = p_wake_up_new_task_ret,
     .entry_handler = p_wake_up_new_task_entry,
     .data_size = sizeof(struct p_wake_up_new_task_data),
-    /* Probe up to 40 instances concurrently. */
-    .maxactive = 40,
 };
 
 


### PR DESCRIPTION
### Description
@redplait observed that we set kprobes' `maxactive` to 40 unconditionally, whereas the actual number could perhaps more reasonably depend on the number of cores. He made this commit in a private fork, but just wouldn't make a pull request on his own - so I am doing it for him.

### How Has This Been Tested?
Relying on CI only.