### PR TITLE
UMH: Allow /usr/libexec/abrt-hook-ccpp for older Red Hat distros

### DIFF
--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -64,6 +64,7 @@ static const char * const p_umh_global[] = {
    "/system/bin/start",
    "/usr/lib/systemd/systemd-cgroups-agent",
    "/usr/lib/systemd/systemd-coredump",
+   "/usr/libexec/abrt-hook-ccpp",
    "/usr/sbin/eppfpga",
    "/usr/sbin/modprobe",
    "/usr/share/apport/apport",


### PR DESCRIPTION
### Description
Add /usr/libexec/abrt-hook-ccpp to UMH allow list. This program path is used on older Red Hat distros.

We're already allow-listing a couple of other pathnames for the same kind of functionality. Actually, this is dangerous non-essential functionality of those distros, which we could want to have LKRG optionally block - so maybe split them out into a separate optional allow list later.

### How Has This Been Tested?
Observed the below upon a program crash on older Fedora prior to this change:

```
[210464.280363] LKRG: ALERT: BLOCK: UMH: Executing program name /usr/libexec/abrt-hook-ccpp
[210464.281292] Core dump to |/usr/libexec/abrt-hook-ccpp 11 0 30372 1000 1000 1668011706 30372 30372 pipe failed
```

Added the path to our allow list. Didn't actually retest yet, but this got to work. ;-)