### PR TITLE
Add synchronization logic around sysctl interface

### DIFF
--- a/src/modules/wrap/p_struct_wrap.h
+++ b/src/modules/wrap/p_struct_wrap.h
@@ -25,6 +25,8 @@
 #ifndef P_LKRG_WRAPPER_H
 #define P_LKRG_WRAPPER_H
 
+extern struct mutex p_ro_page_mutex;
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
 
 static inline void p_set_uid(kuid_t *p_arg, unsigned int p_val) {
@@ -455,6 +457,8 @@ static inline void p_lkrg_open_rw(void) {
 
    unsigned long p_flags;
 
+   mutex_lock(&p_ro_page_mutex);
+
 //   preempt_disable();
    barrier();
    p_set_memory_rw((unsigned long)P_CTRL_ADDR,1);
@@ -472,6 +476,8 @@ static inline void p_lkrg_close_rw(void) {
    p_set_memory_ro((unsigned long)P_CTRL_ADDR,1);
    barrier();
 //   preempt_enable(); //_no_resched();
+
+   mutex_unlock(&p_ro_page_mutex);
 }
 
 /* ARM */
@@ -587,6 +593,8 @@ static inline void p_lkrg_open_rw(void) {
 
    unsigned long p_flags;
 
+   mutex_lock(&p_ro_page_mutex);
+
    preempt_disable();
    barrier();
    p_set_memory_rw((unsigned long)P_CTRL_ADDR,1);
@@ -604,6 +612,8 @@ static inline void p_lkrg_close_rw(void) {
    p_set_memory_ro((unsigned long)P_CTRL_ADDR,1);
    barrier();
    preempt_enable(); //_no_resched();
+
+   mutex_unlock(&p_ro_page_mutex);
 }
 
 /* ARM64 */
@@ -741,6 +751,8 @@ static inline void p_lkrg_open_rw(void) {
 
    unsigned long p_flags;
 
+   mutex_lock(&p_ro_page_mutex);
+
    preempt_disable();
    barrier();
    p_set_memory_rw((unsigned long)P_CTRL_ADDR,1);
@@ -758,6 +770,8 @@ static inline void p_lkrg_close_rw(void) {
    p_set_memory_ro((unsigned long)P_CTRL_ADDR,1);
    barrier();
    preempt_enable(); //_no_resched();
+
+   mutex_unlock(&p_ro_page_mutex);
 }
 
 #endif

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -45,6 +45,8 @@ static enum cpuhp_state p_hot_cpus;
 #endif
 unsigned int p_attr_init = 0;
 
+DEFINE_MUTEX(p_ro_page_mutex);
+
 p_ro_page p_ro __p_lkrg_read_only = {
 
 #if !defined(CONFIG_ARM) && (!defined(P_KERNEL_AGGRESSIVE_INLINING) && defined(CONFIG_X86))


### PR DESCRIPTION
This commit fixes the race problem between 2+ concurrent sysctl updates. It is part of the work related to #204

### Description
The way how the fix is implemented is to move synchronization logic to the `p_lkrg_open/close_rw` interface. The main reason for that is because we use these API outside of sysctl interface as well. We need to synchronize to these usage as well. It makes more sense to have such synchronization logic there.

It is fine to wrap `proc_dointvec_minmax` around mutex and kernel does that as well:
https://elixir.bootlin.com/linux/latest/source/kernel/kprobes.c#L953

TODO: We should rework sysctl interface to reduce the window between the `p_lkrg_open/close_rw` calls. Currently, we do all the work between these calls, but we don't need to. We can call `p_lkrg_close_rw` as soon as we update the control structures, and then do the rest of the work. However, it should be part of different PR.

### How Has This Been Tested?
I run various concurrent processes doing sysctl updates and successfully repro the problem. With these changes, problem didn't repro anymore.
