### PR TITLE
CI: Use latest usable mkosi v14

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -20,7 +20,7 @@ jobs:
               # Native focal package seems to be too old (v5) and not even
               # able to build images properly.
               run: |
-                  sudo python3 -m pip install git+https://github.com/systemd/mkosi.git
+                  sudo python3 -m pip install git+https://github.com/systemd/mkosi.git@v14
                   sudo sed -i 's/linux-generic/linux-virtual/' /usr/local/lib/python*/dist-packages/mkosi/__init__.py
                   sudo rm -f /dev/kvm
                   echo /usr/local/bin >> $GITHUB_PATH

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -18,7 +18,7 @@ jobs:
               # Native focal package seems to be too old (v5) and not even
               # able to build images properly.
               run: |
-                  sudo python3 -m pip install git+https://github.com/systemd/mkosi.git
+                  sudo python3 -m pip install git+https://github.com/systemd/mkosi.git@v14
                   sudo sed -i 's/linux-generic/linux-virtual/' /usr/local/lib/python*/dist-packages/mkosi/__init__.py
                   sudo rm -f /dev/kvm
                   echo /usr/local/bin >> $GITHUB_PATH


### PR DESCRIPTION
Main (and only) branch of mkosi is switching to a bleeding edge systemd tools which are not available on Ubuntu we are testing on. Instead of migrating off mkosi to something else, we can still use some previously wording tag such as `v14'.

Link: https://github.com/lkrg-org/lkrg/issues/253
