### PR TITLE
Add UMH modprobe path for Arch Linux init context

### DIFF
--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -60,6 +60,7 @@ static const char * const p_umh_global[] = {
    "/sbin/tomoyo-init",
    "/sbin/v86d",
    "/system/bin/start",
+   "/usr/bin/modprobe",
    "/usr/lib/systemd/systemd-cgroups-agent",
    "/usr/lib/systemd/systemd-coredump",
    "/usr/libexec/abrt-hook-ccpp",


### PR DESCRIPTION
Address #258 by adding /usr/bin/modprobe to the UMH allow-list.

### Description
Fixes booting on Arch Linux when LKRG is built into the kernel binary

### How Has This Been Tested?
Booted in an Arch Linux VM:
```sh
[root@svl-arch00 ~]# uname -r ; modinfo lkrg |head;sysctl -a|grep umh_
6.1.8
name:           lkrg
filename:       (builtin)
license:        GPL v2
file:           security/lkrg/lkrg
description:    pi3's Linux kernel Runtime Guard
author:         Adam 'pi3' Zabrocki (http://pi3.com.pl)
parm:           log_level:log_level [3 (issue) is default] (uint)
parm:           heartbeat:heartbeat [0 (don't print) is default] (uint)
parm:           block_modules:block_modules [0 (don't block) is default] (uint)
parm:           interval:interval [15 seconds is default] (uint)
lkrg.umh_enforce = 1
lkrg.umh_validate = 1
```

