### PR TITLE
RHEL 9.2 5.14.0-248.el9 aarch64: rename stackframe to unwind_state

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1647,7 +1647,8 @@ int p_ed_enforce_pcfi(struct task_struct *p_task, struct p_ed_process *p_orig, s
    struct stack_frame p_frame;
 #endif
 #elif defined(CONFIG_ARM64)
-#  if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
+#  if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)) \
+   || (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,2))
    struct unwind_state p_frame;
 #  else
    struct stackframe p_frame;


### PR DESCRIPTION
Since kernel-5.14.0-248.el9 struct stackframe is renamed to struct unwind_state on aarch64.
