### PR TITLE
Simplify the use of P_SYM_INIT()

### DIFF
--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -207,10 +207,10 @@ int p_install_ftrace_modify_all_code_hook(void) {
 
    int p_tmp;
 
-   P_SYM_INIT(ftrace_lock, struct mutex *)
-   P_SYM_INIT(ftrace_rec_iter_start, struct ftrace_rec_iter *(*)(void))
-   P_SYM_INIT(ftrace_rec_iter_next, struct ftrace_rec_iter *(*)(struct ftrace_rec_iter *))
-   P_SYM_INIT(ftrace_rec_iter_record, struct dyn_ftrace *(*)(struct ftrace_rec_iter *))
+   P_SYM_INIT(ftrace_lock)
+   P_SYM_INIT(ftrace_rec_iter_start)
+   P_SYM_INIT(ftrace_rec_iter_next)
+   P_SYM_INIT(ftrace_rec_iter_record)
 
    p_ftrace_modify_all_code_kretprobe.maxactive = p_get_kprobe_maxactive();
    if ( (p_tmp = register_kretprobe(&p_ftrace_modify_all_code_kretprobe)) != 0) {

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -247,8 +247,8 @@ int p_install_arch_jump_label_transform_apply_hook(void) {
 
    int p_tmp;
 
-   P_SYM_INIT(tp_vec, struct text_poke_loc **)
-   P_SYM_INIT(tp_vec_nr, int *)
+   P_SYM_INIT(tp_vec)
+   P_SYM_INIT(tp_vec_nr)
 
 // DEBUG
    p_debug_log(P_LOG_DEBUG, "<p_install_arch_jump_label_transform_apply_hook> "

--- a/src/modules/database/arch/p_arch_metadata.c
+++ b/src/modules/database/arch/p_arch_metadata.c
@@ -40,7 +40,7 @@ void p_dump_CPU_metadata(void *_p_arg) {
 
 int p_register_arch_metadata(void) {
 
-   P_SYM_INIT(core_kernel_text, int (*)(unsigned long))
+   P_SYM_INIT(core_kernel_text)
 
 #ifdef P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
 

--- a/src/modules/database/p_database.c
+++ b/src/modules/database/p_database.c
@@ -189,8 +189,8 @@ int p_create_database(void) {
 
    memset(&p_db,0,sizeof(p_hash_database));
 
-   P_SYM_INIT(jump_label_mutex, struct mutex *)
-   P_SYM_INIT(text_mutex, struct mutex *)
+   P_SYM_INIT(jump_label_mutex)
+   P_SYM_INIT(text_mutex)
 
    /*
     * First gather information about CPUs in the system - CRITICAL !!!

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1977,22 +1977,22 @@ int p_exploit_detection_init(void) {
       goto p_exploit_detection_init_out;
    }
 
-   P_SYM_INIT(__kernel_text_address, int (*)(unsigned long))
-   P_SYM_INIT(mm_find_pmd, pmd_t *(*)(struct mm_struct *, unsigned long))
+   P_SYM_INIT(__kernel_text_address)
+   P_SYM_INIT(mm_find_pmd)
 #if defined(CONFIG_SECCOMP)
-   P_SYM_INIT(get_seccomp_filter, void (*)(struct task_struct *))
+   P_SYM_INIT(get_seccomp_filter)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
 #define p___put_seccomp_filter p_put_seccomp_filter
-   P_SYM_INIT(__put_seccomp_filter, void (*)(struct seccomp_filter *))
+   P_SYM_INIT(__put_seccomp_filter)
 #else
-   P_SYM_INIT(put_seccomp_filter, void (*)(struct task_struct *))
+   P_SYM_INIT(put_seccomp_filter)
 #endif
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX
 #if (!defined(RHEL_RELEASE_CODE) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)) || \
      (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 3))
-   P_SYM_INIT(selinux_enabled, int *)
+   P_SYM_INIT(selinux_enabled)
 #endif
    // SELinux information
 #ifdef P_SELINUX_VERIFY

--- a/src/modules/exploit_detection/p_selinux_state.c
+++ b/src/modules/exploit_detection/p_selinux_state.c
@@ -22,7 +22,7 @@
 
 int p_selinux_state_init(void) {
 
-   P_SYM_INIT(selinux_state, struct p_selinux_state *)
+   P_SYM_INIT(selinux_state)
 
    p_selinux_state_update();
    return P_LKRG_SUCCESS;
@@ -45,7 +45,7 @@ int p_selinux_state_enforcing(void) {
  #else
 int p_selinux_state_init(void) {
 
-   P_SYM_INIT(selinux_enforcing, int *)
+   P_SYM_INIT(selinux_enforcing)
 
    p_selinux_state_update();
    return P_LKRG_SUCCESS;

--- a/src/modules/kmod/p_kmod.c
+++ b/src/modules/kmod/p_kmod.c
@@ -28,19 +28,19 @@
 int p_kmod_init(void) {
 
 #if defined(CONFIG_DYNAMIC_DEBUG)
-   P_SYM_INIT(ddebug_tables, struct list_head *)
-   P_SYM_INIT(ddebug_lock, struct mutex *)
+   P_SYM_INIT(ddebug_tables)
+   P_SYM_INIT(ddebug_lock)
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-   P_SYM_INIT(ddebug_remove_module, int(*)(const char *))
+   P_SYM_INIT(ddebug_remove_module)
  #endif
 #endif
 
-   P_SYM_INIT(modules, struct list_head *)
-   P_SYM_INIT(module_kset, struct kset **)
+   P_SYM_INIT(modules)
+   P_SYM_INIT(module_kset)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
-   P_SYM_INIT(module_mutex, struct mutex *)
-   P_SYM_INIT(find_module, struct module* (*)(const char *))
+   P_SYM_INIT(module_mutex)
+   P_SYM_INIT(find_module)
 #else
    P_SYM(p_module_mutex)     = (struct mutex *)&module_mutex;
    P_SYM(p_find_module)      = (struct module* (*)(const char *))find_module;

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -430,17 +430,17 @@ static int __init p_lkrg_register(void) {
       return P_LKRG_GENERAL_ERROR;
    }
 
-   P_SYM_INIT(freeze_processes, int (*)(void))
-   P_SYM_INIT(thaw_processes, void (*)(void))
+   P_SYM_INIT(freeze_processes)
+   P_SYM_INIT(thaw_processes)
 #if defined(CONFIG_X86) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
-   P_SYM_INIT(native_write_cr4, void (*)(unsigned long))
+   P_SYM_INIT(native_write_cr4)
 #endif
 #ifdef P_LKRG_UNEXPORTED_MODULE_ADDRESS
-   P_SYM_INIT(__module_address, struct module *(*)(unsigned long))
-   P_SYM_INIT(__module_text_address, struct module *(*)(unsigned long))
+   P_SYM_INIT(__module_address)
+   P_SYM_INIT(__module_text_address)
 #endif
 #if defined(CONFIG_OPTPROBES)
-   P_SYM_INIT(wait_for_kprobe_optimizer, void (*)(void))
+   P_SYM_INIT(wait_for_kprobe_optimizer)
 #endif
 
    // Freeze all non-kernel processes
@@ -500,22 +500,22 @@ static int __init p_lkrg_register(void) {
    p_cpu = 1;
 
 #if !defined(CONFIG_ARM64)
-   P_SYM_INIT(flush_tlb_all, void (*)(void))
+   P_SYM_INIT(flush_tlb_all)
 #endif
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   P_SYM_INIT(set_memory_ro, int (*)(unsigned long, int))
-   P_SYM_INIT(set_memory_rw, int (*)(unsigned long, int))
+   P_SYM_INIT(set_memory_ro)
+   P_SYM_INIT(set_memory_rw)
 
  #if defined(CONFIG_ARM64)
-   P_SYM_INIT(set_memory_valid, int (*)(unsigned long, int, int))
+   P_SYM_INIT(set_memory_valid)
  #endif
 
 #else
  #if defined(CONFIG_X86)
-   P_SYM_INIT(change_page_attr_set_clr, int (*)(unsigned long *, int, pgprot_t, pgprot_t, int, int, struct page **))
+   P_SYM_INIT(change_page_attr_set_clr)
  #elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
-   P_SYM_INIT(change_memory_common, int (*)(unsigned long, int, pgprot_t, pgprot_t))
+   P_SYM_INIT(change_memory_common)
  #else
    p_print_log(P_LOG_FATAL, "Unsupported platform");
    p_ret = P_LKRG_GENERAL_ERROR;

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -319,8 +319,8 @@ extern p_ro_page p_ro;
 #define P_CTRL(p_field) p_ro.p_lkrg_global_ctrl.ctrl.p_field
 #define P_CTRL_ADDR &p_ro.p_lkrg_global_ctrl
 
-#define P_SYM_INIT(sym, type) \
-   if (!(P_SYM(p_ ## sym) = (type)P_SYM(p_kallsyms_lookup_name)(#sym))) { \
+#define P_SYM_INIT(sym) \
+   if (!(P_SYM(p_ ## sym) = (typeof(P_SYM(p_ ## sym)))P_SYM(p_kallsyms_lookup_name)(#sym))) { \
       p_print_log(P_LOG_FATAL, "Can't find '" #sym "'"); \
       goto p_sym_error; \
    }


### PR DESCRIPTION
### Description
<!--- Describe your changes -->
I simplified the usage of P_SYM_INIT by removing the second parameter - type declaration. I think this is unnecessary because type declaration is done during variable definition, not during variable initialization.


### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I compiled it successfully on Ubuntu 22.04 and did not encounter any errors when running it.
