### PR TITLE
make bootup scripts independent of cwd, add usage and root checks

### DIFF
--- a/README
+++ b/README
@@ -197,7 +197,8 @@ If everything is right, you should get similar output to the following:
 
 Please refer to the previous two sections for how to start the LKRG service or
 have it started on system bootup.  If you wish to use the unit/init file, you
-must install it manually.
+must install it manually, e.g., by running the `lkrg-bootup.sh` script
+located under `scripts/bootup/` with the `install` subcommand (as root).
 
 
 Uninstalling

--- a/scripts/bootup/lkrg-bootup.sh
+++ b/scripts/bootup/lkrg-bootup.sh
@@ -6,13 +6,26 @@
 #  - Adam 'pi3' Zabrocki (http://pi3.com.pl)
 ##
 
-P_LKRG_SYSTEMD="scripts/bootup/systemd/lkrg-systemd.sh"
-P_LKRG_OPENRC="scripts/bootup/openrc/lkrg-openrc.sh"
+set -eu
+
+P_SCRIPT_DIR="$(dirname "$0")"
+P_LKRG_SYSTEMD="${P_SCRIPT_DIR}/systemd/lkrg-systemd.sh"
+P_LKRG_OPENRC="${P_SCRIPT_DIR}/openrc/lkrg-openrc.sh"
 
 P_RED='\033[0;31m'
 P_GREEN='\033[0;32m'
 P_WHITE='\033[1;37m'
 P_NC='\033[0m' # No Color
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 (install|uninstall)" >&2
+	exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "Please run as root." >&2
+	exit 1
+fi
 
 echo -e " ${P_GREEN}[*] ${P_WHITE}Executing LKRG's bootup installation script${P_NC}"
 

--- a/scripts/bootup/openrc/lkrg-openrc.sh
+++ b/scripts/bootup/openrc/lkrg-openrc.sh
@@ -7,8 +7,11 @@
 #  - Jakub 'mrl5' Kołodziejczak (https://github.com/mrl5)
 ##
 
+set -eu
+
 P_SYSCTL_DIR="/etc/sysctl.d"
 P_INITD_DIR="/etc/init.d"
+P_SCRIPT_DIR="$(dirname "$0")"
 RUNLEVEL="boot"
 
 
@@ -18,6 +21,16 @@ P_WHITE='\033[1;37m'
 P_YL='\033[1;33m'
 P_NC='\033[0m' # No Color
 
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 (install|uninstall)" >&2
+	exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "Please run as root." >&2
+	exit 1
+fi
+
 echo -e "  ${P_GREEN}[+] ${P_WHITE}OpenRC detected${P_NC}"
 
 if [ "$1" == "install" ]; then
@@ -26,7 +39,7 @@ if [ "$1" == "install" ]; then
 		exit 1
 	else
 		echo -e "       ${P_GREEN}Installing ${P_YL}lkrg${P_GREEN} file under ${P_YL}$P_INITD_DIR${P_GREEN} directory${P_NC}"
-		install -pm 755 -o root -g root scripts/bootup/openrc/lkrg "$P_INITD_DIR/lkrg"
+		install -pm 755 -o root -g root "${P_SCRIPT_DIR}/lkrg" "$P_INITD_DIR/lkrg"
 		echo -e "       ${P_GREEN}To start ${P_YL}lkrg${P_GREEN} please use: ${P_YL}/etc/init.d/lkrg start${P_NC}"
 		echo -e "       ${P_GREEN}To enable ${P_YL}lkrg${P_GREEN} on bootup please use: ${P_YL}rc-update add lkrg ${RUNLEVEL}${P_NC}"
 	fi
@@ -34,7 +47,7 @@ if [ "$1" == "install" ]; then
 		echo -e "       ${P_YL}01-lkrg.conf${P_GREEN} is already installed, skipping${P_NC}"
 	else
 		echo -e "       ${P_GREEN}Installing ${P_YL}01-lkrg.conf${P_GREEN} file under ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
-		install -pm 644 -o root -g root scripts/bootup/lkrg.conf "$P_SYSCTL_DIR/01-lkrg.conf"
+		install -pm 644 -o root -g root "${P_SCRIPT_DIR}/../lkrg.conf" "$P_SYSCTL_DIR/01-lkrg.conf"
 	fi
 elif [ "$1" == "uninstall" ]; then
 	echo -e "       ${P_GREEN}Stopping ${P_YL}lkrg${P_NC}"
@@ -43,7 +56,7 @@ elif [ "$1" == "uninstall" ]; then
 	rc-update del lkrg ${RUNLEVEL}
 	echo -e "       ${P_GREEN}Deleting ${P_YL}lkrg${P_GREEN} file from ${P_YL}$P_SYSTEMD_DIR${P_GREEN} directory${P_NC}"
 	rm "$P_INITD_DIR/lkrg"
-	if cmp -s "$P_SYSCTL_DIR/01-lkrg.conf" scripts/bootup/lkrg.conf; then
+	if cmp -s "$P_SYSCTL_DIR/01-lkrg.conf" "${P_SCRIPT_DIR}/../lkrg.conf"; then
 		echo -e "       ${P_GREEN}Deleting unmodified ${P_YL}01-lkrg.conf${P_GREEN} file from ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
 		rm "$P_SYSCTL_DIR/01-lkrg.conf"
 	elif [ -e "$P_SYSCTL_DIR/01-lkrg.conf" ]; then

--- a/scripts/bootup/systemd/lkrg-systemd.sh
+++ b/scripts/bootup/systemd/lkrg-systemd.sh
@@ -6,8 +6,11 @@
 #  - Adam 'pi3' Zabrocki (http://pi3.com.pl)
 ##
 
+set -eu
+
 P_SYSCTL_DIR="/etc/sysctl.d"
 P_SYSTEMD_DIR="/etc/systemd/system"
+P_SCRIPT_DIR="$(dirname "$0")"
 
 
 P_RED='\033[0;31m'
@@ -15,6 +18,16 @@ P_GREEN='\033[0;32m'
 P_WHITE='\033[1;37m'
 P_YL='\033[1;33m'
 P_NC='\033[0m' # No Color
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 (install|uninstall)" >&2
+	exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "Please run as root." >&2
+	exit 1
+fi
 
 echo -e "  ${P_GREEN}[+] ${P_WHITE}Systemd detected${P_NC}"
 
@@ -24,7 +37,7 @@ if [ "$1" == "install" ]; then
 		exit 1
 	else
 		echo -e "       ${P_GREEN}Installing ${P_YL}lkrg.service${P_GREEN} file under ${P_YL}$P_SYSTEMD_DIR${P_GREEN} directory${P_NC}"
-		install -pm 644 -o root -g root scripts/bootup/systemd/lkrg.service "$P_SYSTEMD_DIR/lkrg.service"
+		install -pm 644 -o root -g root "${P_SCRIPT_DIR}/lkrg.service" "${P_SYSTEMD_DIR}/lkrg.service"
 		echo -e "       ${P_GREEN}To start ${P_YL}lkrg.service${P_GREEN} please use: ${P_YL}systemctl start lkrg${P_NC}"
 		echo -e "       ${P_GREEN}To enable ${P_YL}lkrg.service${P_GREEN} on bootup please use: ${P_YL}systemctl enable lkrg.service${P_NC}"
 	fi
@@ -32,7 +45,7 @@ if [ "$1" == "install" ]; then
 		echo -e "       ${P_YL}01-lkrg.conf${P_GREEN} is already installed, skipping${P_NC}"
 	else
 		echo -e "       ${P_GREEN}Installing ${P_YL}01-lkrg.conf${P_GREEN} file under ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
-		install -pm 644 -o root -g root scripts/bootup/lkrg.conf "$P_SYSCTL_DIR/01-lkrg.conf"
+		install -pm 644 -o root -g root "${P_SCRIPT_DIR}/../lkrg.conf" "${P_SYSCTL_DIR}/01-lkrg.conf"
 	fi
 elif [ "$1" == "uninstall" ]; then
 	echo -e "       ${P_GREEN}Stopping ${P_YL}lkrg.service${P_NC}"
@@ -41,7 +54,7 @@ elif [ "$1" == "uninstall" ]; then
 	systemctl disable lkrg.service
 	echo -e "       ${P_GREEN}Deleting ${P_YL}lkrg.service${P_GREEN} file from ${P_YL}$P_SYSTEMD_DIR${P_GREEN} directory${P_NC}"
 	rm "$P_SYSTEMD_DIR/lkrg.service"
-	if cmp -s "$P_SYSCTL_DIR/01-lkrg.conf" scripts/bootup/lkrg.conf; then
+	if cmp -s "$P_SYSCTL_DIR/01-lkrg.conf" "${P_SCRIPT_DIR}/../lkrg.conf"; then
 		echo -e "       ${P_GREEN}Deleting unmodified ${P_YL}01-lkrg.conf${P_GREEN} file from ${P_YL}$P_SYSCTL_DIR${P_GREEN} directory${P_NC}"
 		rm "$P_SYSCTL_DIR/01-lkrg.conf"
 	elif [ -e "$P_SYSCTL_DIR/01-lkrg.conf" ]; then


### PR DESCRIPTION
### Description
For my use case it happened that I ran the install scripts not from the root of the project (and not through make). I noticed that they fail "silently" in that case. I thought it would not hurt to update the scripts to be more self-sufficient, i.e., independent of the cwd and with some usage and root checks.

### How Has This Been Tested?
Tested that it works as expected for systemd, cannot say anything about the openrc part.