### PR TITLE
CI: mkosi-mainline: Workaround 'dpkg: error: dpkg frontend lock'

### DIFF
--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -20,6 +20,7 @@ jobs:
               run: |
                   sudo python3 -m pip install git+https://github.com/systemd/mkosi.git@v14
                   sudo sed -i 's/linux-generic/linux-virtual/' /usr/local/lib/python*/dist-packages/mkosi/__init__.py
+                  sudo sed -i 's/dpkg-reconfigure dracut/&||:/' /usr/local/lib/python*/dist-packages/mkosi/resources/dpkg-reconfigure-dracut.install
                   sudo rm -f /dev/kvm
                   echo /usr/local/bin >> $GITHUB_PATH
 


### PR DESCRIPTION
Mkosi's own dracut hook, which is triggered from `dpkg -i`, calls `dpkg-reconfigure` causing dpkg frontend lock conflict. But `initrd.img` is generated correctly. Workaround by ignoring `dpkg-reconfigure` errors in the hook.

  dpkg: error: dpkg frontend lock was locked by another process with pid 5
  Note: removing the lock file is always wrong, can damage the locked area
  and the entire system. See <https://wiki.debian.org/Teams/Dpkg/FAQ#db-lock>.
  run-parts: /etc/kernel/postinst.d/zz-systemd-boot exited with return code 2

Link: https://github.com/lkrg-org/lkrg/issues/283

### Description
I did not investigate thoroughly all internal workings of `dpkg -i`/`dpkg-reconfigure` and what is changed since last week in Ubuntu (old action logs are not enough to clarify this.)

### How Has This Been Tested?
Locally.
