### PR TITLE
CI: Update workflows to use latest versions of the actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,16 +25,16 @@ jobs:
                     - image: registry.opensuse.org/opensuse/tumbleweed
                       run: zypper -n install -y gcc make kernel-default-devel awk
                     - image: registry.opensuse.org/opensuse/leap
-                      run: zypper -n install -y gcc make kernel-default-devel
+                      run: zypper -n install -y gcc make kernel-default-devel tar gzip
 
         container:
             image: ${{ matrix.image }}
             options: --security-opt seccomp=unconfined
 
         steps:
-            - uses: actions/checkout@v1
             - run: cat /etc/os-release
             - run: ${{ matrix.run }}
+            - uses: actions/checkout@v3
             - run: make -j$(nproc) KERNELRELEASE=$(cd /lib/modules; ls)
 
 # vim: sw=4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -29,8 +29,8 @@ jobs:
                     - image: i386/ubuntu:bionic
                       packages: libelf-dev linux-headers-generic
         steps:
-            - uses: docker/setup-qemu-action@v1
-            - uses: actions/checkout@v1
+            - uses: docker/setup-qemu-action@v2
+            - uses: actions/checkout@v3
             - name: Create Dockerfile
               run: |
                   cat <<EOF >Dockerfile

--- a/.github/workflows/docker-boot.yml
+++ b/.github/workflows/docker-boot.yml
@@ -30,14 +30,14 @@ jobs:
                       install: qemu-system-arm
 
         steps:
-            - uses: docker/setup-qemu-action@v1
+            - uses: docker/setup-qemu-action@v2
             - run: sudo apt-get update
               # It's possible to update QEMU to (6.0) on focal (ubuntu-20.04) with
               #   add-apt-repository ppa:canonical-server/server-backports
               # but this is still not enough to boot & power-off raspi2b properly.
             - run: sudo apt-get install -y qemu-utils e2fsprogs expect ${{ matrix.install }}
 
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - name: Enable LKRG debugging options
               run: |
                   sed -i '/P_LKRG_JUMP_LABEL_STEXT_DEBUG/s/\/\///' src/modules/print_log/p_lkrg_print_log.h

--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -13,7 +13,7 @@ jobs:
                     - focal
                     - jammy
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - run: sudo apt-get update
             - run: sudo apt-get install -y debootstrap qemu-system-x86 systemd-container expect
             - name: Install mkosi from git

--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -11,7 +11,7 @@ jobs:
         if: ${{ github.repository == 'lkrg-org/lkrg' || github.event_name != 'schedule' }}
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - run: sudo apt-get update
             - run: sudo apt-get install -y debootstrap qemu-system-x86 systemd-container expect sysvbanner
             - name: Install mkosi from git


### PR DESCRIPTION
This should quiet the warning:

> The following actions uses node12 which is deprecated and will be  forced to run on node16: actions/checkout@v2. For more info:  https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
