### PR TITLE
CI: Update openSUSE docker builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,7 @@ jobs:
                     - image: alt:sisyphus
                       run: apt-get update; apt-get install -y kernel-headers-modules-un-def gcc make libelf-devel
                     - image: opensuse/tumbleweed
-                      run: zypper -n install -y gcc make kernel-default-devel
+                      run: zypper -n install -y gcc make kernel-default-devel awk
                     - image: opensuse/leap
                       run: zypper -n install -y gcc make kernel-default-devel
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -22,9 +22,9 @@ jobs:
                       run: dnf install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: alt:sisyphus
                       run: apt-get update; apt-get install -y kernel-headers-modules-un-def gcc make libelf-devel
-                    - image: opensuse/tumbleweed
+                    - image: registry.opensuse.org/opensuse/tumbleweed
                       run: zypper -n install -y gcc make kernel-default-devel awk
-                    - image: opensuse/leap
+                    - image: registry.opensuse.org/opensuse/leap
                       run: zypper -n install -y gcc make kernel-default-devel
 
         container:


### PR DESCRIPTION
### Description
`opensuse/tumbleweed` requires `awk` and docker hub images are deprecated.

### How Has This Been Tested?
On my fork.

