### PR TITLE
CI: mkosi: Fix mainline boot on Ubuntu mantic

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -11,7 +11,7 @@ Release=hirsute
 [Output]
 Bootable=yes
 # 'no_timer_check' is old workaround to intermittent apic kernel panic in qemu.
-KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1 ignore_loglevel
+KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1 ignore_loglevel root=LABEL=root
 # Separate initrd for possible debugging.
 WithUnifiedKernelImages=no
 


### PR DESCRIPTION
Ubuntu removed 'systemd-gpt-auto-generator' from systemd_253.5-1ubuntu5, causing dracut to be unable to find the root partition without assistance. It appears that specifying the root label could be a good solution.

Fixes: https://github.com/lkrg-org/lkrg/issues/287

### How Has This Been Tested?
Will be tested in this PR.
