### PR TITLE
Some small fixes and possible valuable information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ modules.order
 *.o.ur-safe
 *.o
 .cache.mk
+lkrg.mod
 
 # kcov
 *.gcno

--- a/README
+++ b/README
@@ -142,8 +142,7 @@ for OpenRC:
 
 for other:
 
-  sudo -s 
-  modprobe -v lkrg
+  sudo modprobe -v lkrg
 
 
 Autoload on bootup

--- a/README
+++ b/README
@@ -142,7 +142,8 @@ for OpenRC:
 
 for other:
 
-	sudo modprobe -v lkrg
+  sudo -s 
+  modprobe -v lkrg
 
 
 Autoload on bootup

--- a/mkosi.default
+++ b/mkosi.default
@@ -11,7 +11,7 @@ Release=hirsute
 [Output]
 Bootable=yes
 # 'no_timer_check' is old workaround to intermittent apic kernel panic in qemu.
-KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1 ignore_loglevel
+KernelCommandLine=no_timer_check panic=-1 oops=panic panic_on_warn softlockup_panic=1 ignore_loglevel root=LABEL=root
 # Separate initrd for possible debugging.
 WithUnifiedKernelImages=no
 

--- a/scripts/add-exports.sh
+++ b/scripts/add-exports.sh
@@ -8,3 +8,9 @@ echo "EXPORT_SYMBOL(lookup_fast);" >> fs/namei.c
 # keep symbol export inside the ifdef block defining the symbol
 sed -i '/static void __seccomp_filter_release.*/iEXPORT_SYMBOL(__put_seccomp_filter);\n' kernel/seccomp.c
 echo "EXPORT_SYMBOL(do_seccomp);" >> kernel/seccomp.c
+# fixes modpost errors
+sed -i 's/static int change_page_attr_set_clr/int change_page_attr_set_clr/g'  arch/x86/mm/pat/set_memory.c
+sed -i 's/static struct dentry \*lookup_fast/struct dentry \*lookup_fast/g' fs/namei.c
+sed -i 's/static long do_seccomp/long do_seccomp/g' kernel/seccomp.c
+sed -i 's/static void __seccomp_filter_release(/void __seccomp_filter_release(/g' kernel/seccomp.c
+sed -i 's/static void __put_seccomp_filter/void __put_seccomp_filter/g' kernel/seccomp.c

--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -65,7 +65,7 @@ echo "and Makefile"
 echo "$MAKEFILE"
 echo "Commit msg: $COMMIT"
 echo "Ctrl+c to quit, any other key to continue"
-#removed
+read CANCEL
 # Execute copy
 mkdir -p "$LDIR"
 echo "$KCONFIG" > "$LDIR/Kconfig"

--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -65,7 +65,7 @@ echo "and Makefile"
 echo "$MAKEFILE"
 echo "Commit msg: $COMMIT"
 echo "Ctrl+c to quit, any other key to continue"
-read CANCEL
+#removed
 # Execute copy
 mkdir -p "$LDIR"
 echo "$KCONFIG" > "$LDIR/Kconfig"

--- a/scripts/copy-builtin.sh
+++ b/scripts/copy-builtin.sh
@@ -65,6 +65,7 @@ echo "and Makefile"
 echo "$MAKEFILE"
 echo "Commit msg: $COMMIT"
 echo "Ctrl+c to quit, any other key to continue"
+
 read CANCEL
 # Execute copy
 mkdir -p "$LDIR"

--- a/src/modules/database/p_database.c
+++ b/src/modules/database/p_database.c
@@ -32,13 +32,19 @@ int hash_from_ex_table(void) {
 
    p_db.kernel_ex_table.p_size = (unsigned long)(p_tmp - (unsigned long)p_db.kernel_ex_table.p_addr);
 
-   p_db.kernel_ex_table.p_hash = p_lkrg_fast_hash((unsigned char *)p_db.kernel_ex_table.p_addr,
-                                                  (unsigned int)p_db.kernel_ex_table.p_size);
+   if(p_db.kernel_ex_table.p_size != 0) {
+      p_db.kernel_ex_table.p_hash = p_lkrg_fast_hash( (unsigned char *)p_db.kernel_ex_table.p_addr,
+                                                      (unsigned int)p_db.kernel_ex_table.p_size);
+   } else {
+      p_debug_log(P_LOG_DEBUG,
+          "hashing of _ex_table failed, is kptr_restrict set or CAP_SYSLOG missing?");
+      p_db.kernel_ex_table.p_hash = 0xFFFFFFFF;
+   }
 
    p_debug_log(P_LOG_DEBUG,
-          "hash [0x%llx] ___ex_table start [0x%lx] size [0x%lx]",p_db.kernel_ex_table.p_hash,
-                                                                   (long)p_db.kernel_ex_table.p_addr,
-                                                                   (long)p_db.kernel_ex_table.p_size);
+      "hash [0x%llx] ___ex_table start [0x%lx] size [0x%lx]",p_db.kernel_ex_table.p_hash,
+                                                               (long)p_db.kernel_ex_table.p_addr,
+                                                               (long)p_db.kernel_ex_table.p_size);
 
    return P_LKRG_SUCCESS;
 }
@@ -95,10 +101,12 @@ int hash_from_kernel_rodata(void) {
 
 #if !defined(CONFIG_GRKERNSEC)
 
-   if(p_db.kernel_rodata.p_size != 0x0) {
+   if(p_db.kernel_rodata.p_size != 0) {
       p_db.kernel_rodata.p_hash = p_lkrg_fast_hash((unsigned char *)p_db.kernel_rodata.p_addr,
                                                    (unsigned int)p_db.kernel_rodata.p_size);
    } else {
+      p_debug_log(P_LOG_DEBUG,
+          "hashing of _rodata failed, is kptr_restrict set or CAP_SYSLOG missing?"
       p_db.kernel_rodata.p_hash = 0xFFFFFFFF;
    }
 
@@ -139,10 +147,16 @@ int hash_from_iommu_table(void) {
    p_db.kernel_iommu_table.p_hash = 0xFFFFFFFF;
 #endif
 
-   p_debug_log(P_LOG_DEBUG,
-          "hash [0x%llx] __iommu_table start [0x%lx] size [0x%lx]",p_db.kernel_iommu_table.p_hash,
-                                                                     (long)p_db.kernel_iommu_table.p_addr,
-                                                                     (long)p_db.kernel_iommu_table.p_size);
+   if(p_db.kernel_iommu_table.p_size != 0) {
+      p_debug_log(P_LOG_DEBUG,
+            "hash [0x%llx] __iommu_table start [0x%lx] size [0x%lx]",p_db.kernel_iommu_table.p_hash,
+                                                                        (long)p_db.kernel_iommu_table.p_addr,
+                                                                        (long)p_db.kernel_iommu_table.p_size);
+   } else {
+      p_debug_log(P_LOG_DEBUG,
+          "hashing of iommu failed, is kptr_restrict set or CAP_SYSLOG missing?"
+      p_db.kernel_iommu_table.p_hash = 0xFFFFFFFF;
+   }
 
 #else
 

--- a/src/modules/database/p_database.c
+++ b/src/modules/database/p_database.c
@@ -95,8 +95,12 @@ int hash_from_kernel_rodata(void) {
 
 #if !defined(CONFIG_GRKERNSEC)
 
-   p_db.kernel_rodata.p_hash = p_lkrg_fast_hash((unsigned char *)p_db.kernel_rodata.p_addr,
-                                                (unsigned int)p_db.kernel_rodata.p_size);
+   if(p_db.kernel_rodata.p_size != 0x0) {
+      p_db.kernel_rodata.p_hash = p_lkrg_fast_hash((unsigned char *)p_db.kernel_rodata.p_addr,
+                                                   (unsigned int)p_db.kernel_rodata.p_size);
+   } else {
+      p_db.kernel_rodata.p_hash = 0xFFFFFFFF;
+   }
 
 #else
 

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -379,7 +379,11 @@ int p_ed_wq_valid_cache_init(void) {
 
 static void p_ed_wq_valid_cache_delete(void) {
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+   __flush_workqueue(system_unbound_wq);
+#else 
    flush_workqueue(system_unbound_wq);
+#endif
    if (p_ed_wq_valid_cache) {
       kmem_cache_destroy(p_ed_wq_valid_cache);
       p_ed_wq_valid_cache = NULL;

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -162,7 +162,7 @@ static const struct p_functions_hooks {
      "Won't enforce validation on 'generic_permission'",
      1
    },
-#ifdef CONFIG_SECURITY_SELINUX
+#ifdef CONFIG_SECURITY_SELINUX_DEVELOP
    { "sel_write_enforce",
      p_install_sel_write_enforce_hook,
      p_uninstall_sel_write_enforce_hook,

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
@@ -19,7 +19,7 @@
  */
 
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
-#define P_LKRG_EXPLOIT_DETECTION_SECURTIY_PTRACE_ACCESS_H
+#define P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 
 struct p_security_ptrace_access_data {
     ktime_t entry_stamp;

--- a/src/modules/hashing/p_lkrg_fast_hash.c
+++ b/src/modules/hashing/p_lkrg_fast_hash.c
@@ -30,7 +30,7 @@ notrace uint64_t p_lkrg_fast_hash(const char *p_data, unsigned int p_len) {
 
    uint64_t p_tmp = 0;
 
-   p_lkrg_siphash(p_data, p_len, (uint8_t *)&p_global_siphash_key, (uint8_t *)&p_tmp, sizeof(p_tmp));
+   p_lkrg_siphash((uint8_t *)p_data, p_len, (uint8_t *)&p_global_siphash_key, (uint8_t *)&p_tmp, sizeof(p_tmp));
    return p_tmp;
 }
 

--- a/src/modules/hashing/p_lkrg_fast_hash.c
+++ b/src/modules/hashing/p_lkrg_fast_hash.c
@@ -26,11 +26,11 @@ uint128_t p_global_siphash_key;
 inline void p_lkrg_siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
                            uint8_t *out, const size_t outlen);
 
-notrace uint64_t p_lkrg_fast_hash(const char *p_data, unsigned int p_len) {
+notrace uint64_t p_lkrg_fast_hash(const unsigned char *p_data, unsigned int p_len) {
 
    uint64_t p_tmp = 0;
 
-   p_lkrg_siphash((uint8_t *)p_data, p_len, (uint8_t *)&p_global_siphash_key, (uint8_t *)&p_tmp, sizeof(p_tmp));
+   p_lkrg_siphash((uint8_t *)p_data, (size_t)p_len, (uint8_t *)&p_global_siphash_key, (uint8_t *)&p_tmp, sizeof(p_tmp));
    return p_tmp;
 }
 

--- a/src/modules/hashing/p_lkrg_fast_hash.c
+++ b/src/modules/hashing/p_lkrg_fast_hash.c
@@ -30,7 +30,7 @@ notrace uint64_t p_lkrg_fast_hash(const unsigned char *p_data, unsigned int p_le
 
    uint64_t p_tmp = 0;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 1)
    p_tmp = siphash((const void *)p_data, (size_t)p_len, &p_global_siphash_key);
  #else
    p_lkrg_siphash((uint8_t *)p_data, (size_t)p_len, (uint8_t *)&p_global_siphash_key, (uint8_t *)&p_tmp, sizeof(p_tmp));  
@@ -39,7 +39,7 @@ notrace uint64_t p_lkrg_fast_hash(const unsigned char *p_data, unsigned int p_le
    return p_tmp;
 }
 
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 6, 0)
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 1, 1)
 notrace inline void p_lkrg_siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
                                    uint8_t *out, const size_t outlen) {
 

--- a/src/modules/hashing/p_lkrg_fast_hash.c
+++ b/src/modules/hashing/p_lkrg_fast_hash.c
@@ -45,8 +45,8 @@ notrace inline void p_lkrg_siphash(const uint8_t *in, const size_t inlen, const 
    uint64_t k1 = U8TO64_LE(k + 8);
    uint64_t m;
    int i;
-   const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
-   const int left = inlen & 7;
+   const uint8_t *end = in + inlen - (inlen % 8);
+   const uint8_t left = inlen & 7;
    uint64_t b = ((uint64_t)inlen) << 56;
    v3 ^= k1;
    v2 ^= k0;
@@ -65,25 +65,25 @@ notrace inline void p_lkrg_siphash(const uint8_t *in, const size_t inlen, const 
 
    switch (left) {
       case 7:
-         b |= ((uint64_t)in[6]) << 48;
+         b |= ((uint64_t)end[6]) << 48;
          P_FALL_THROUGH;
       case 6:
-         b |= ((uint64_t)in[5]) << 40;
+         b |= ((uint64_t)end[5]) << 40;
          P_FALL_THROUGH;
       case 5:
-         b |= ((uint64_t)in[4]) << 32;
+         b |= ((uint64_t)end[4]) << 32;
          P_FALL_THROUGH;
       case 4:
-         b |= ((uint64_t)in[3]) << 24;
+         b |= ((uint64_t)end[3]) << 24;
          P_FALL_THROUGH;
       case 3:
-         b |= ((uint64_t)in[2]) << 16;
+         b |= ((uint64_t)end[2]) << 16;
          P_FALL_THROUGH;
       case 2:
-         b |= ((uint64_t)in[1]) << 8;
+         b |= ((uint64_t)end[1]) << 8;
          P_FALL_THROUGH;
       case 1:
-         b |= ((uint64_t)in[0]);
+         b |= ((uint64_t)end[0]);
          break;
       case 0:
          break;

--- a/src/modules/hashing/p_lkrg_fast_hash.c
+++ b/src/modules/hashing/p_lkrg_fast_hash.c
@@ -51,8 +51,8 @@ notrace inline void p_lkrg_siphash(const uint8_t *in, const size_t inlen, const 
    uint64_t k1 = U8TO64_LE(k + 8);
    uint64_t m;
    int i;
-   const uint8_t *end = in + inlen - (inlen % 8);
-   const uint8_t left = inlen & 7;
+   const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
+   const uint8_t left = inlen & (sizeof(uint64_t) - 1);
    uint64_t b = ((uint64_t)(inlen)) << 56;
    v3 ^= k1;
    v2 ^= k0;

--- a/src/modules/hashing/p_lkrg_fast_hash.h
+++ b/src/modules/hashing/p_lkrg_fast_hash.h
@@ -78,6 +78,6 @@ typedef struct uint128_t {
 
 extern uint128_t p_global_siphash_key;
 
-uint64_t p_lkrg_fast_hash(const char *data, unsigned int len);
+uint64_t p_lkrg_fast_hash(const unsigned char *data, unsigned int len);
 
 #endif

--- a/src/modules/hashing/p_lkrg_fast_hash.h
+++ b/src/modules/hashing/p_lkrg_fast_hash.h
@@ -53,10 +53,10 @@ typedef struct uint128_t {
     U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
 
 #define U8TO64_LE(p)                                                           \
-    (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \
-     ((uint64_t)((p)[2]) << 16) | ((uint64_t)((p)[3]) << 24) |                 \
-     ((uint64_t)((p)[4]) << 32) | ((uint64_t)((p)[5]) << 40) |                 \
-     ((uint64_t)((p)[6]) << 48) | ((uint64_t)((p)[7]) << 56))
+    (((uint64_t)(p[0])) | ((uint64_t)(p[1]) << 8) |                        \
+     ((uint64_t)(p[2]) << 16) | ((uint64_t)(p[3]) << 24) |                 \
+     ((uint64_t)(p[4]) << 32) | ((uint64_t)(p[5]) << 40) |                 \
+     ((uint64_t)(p[6]) << 48) | ((uint64_t)(p[7]) << 56))
 
 #define SIPROUND                                                               \
     do {                                                                       \
@@ -76,7 +76,7 @@ typedef struct uint128_t {
         v2 = ROTL(v2, 32);                                                     \
     } while (0)
 
-extern uint128_t p_global_siphash_key;
+extern p_global_siphash_key_t p_global_siphash_key;
 
 uint64_t p_lkrg_fast_hash(const unsigned char *data, unsigned int len);
 

--- a/src/modules/integrity_timer/p_integrity_timer.c
+++ b/src/modules/integrity_timer/p_integrity_timer.c
@@ -51,7 +51,11 @@ int p_offload_cache_init(void) {
 
 void p_offload_cache_delete(void) {
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+   __flush_workqueue(system_unbound_wq);
+#else 
    flush_workqueue(system_unbound_wq);
+#endif
    if (p_offload_cache) {
       kmem_cache_destroy(p_offload_cache);
       p_offload_cache = NULL;

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
@@ -28,7 +28,11 @@ static struct kretprobe p_lkrg_dummy_kretprobe = {
     .entry_handler = p_lkrg_dummy_entry,
 };
 
+#ifdef __clang__
 __attribute__ ((optnone))
+#else
+__attribute__((optimize(0)))
+#endif
 noinline int lkrg_dummy(int arg) {
 
    p_debug_log(P_LOG_DEBUG,

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
@@ -28,7 +28,7 @@ static struct kretprobe p_lkrg_dummy_kretprobe = {
     .entry_handler = p_lkrg_dummy_entry,
 };
 
-__attribute__((optimize(0)))
+__attribute__ ((optnone))
 noinline int lkrg_dummy(int arg) {
 
    p_debug_log(P_LOG_DEBUG,

--- a/src/modules/print_log/p_lkrg_print_log.h
+++ b/src/modules/print_log/p_lkrg_print_log.h
@@ -137,6 +137,8 @@
    case P_LOG_FLOOD:                                                                       \
       p_print_ret = printk(KERN_DEBUG   P_LKRG_SIGNATURE "FLOOD: " p_fmt "\n", ## p_args); \
       break;                                                                               \
+   default:                                                                                \
+      break;                                                                               \
    }                                                                                       \
                                                                                            \
    p_print_ret;                                                                            \

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -403,8 +403,7 @@ static int __init p_lkrg_register(void) {
    /*
     * Generate random SipHash key
     */
-   p_global_siphash_key.p_low  = (uint64_t)get_random_long();
-   p_global_siphash_key.p_high = (uint64_t)get_random_long();
+   p_lkrg_set_siphash_key();
 
    p_parse_module_params();
    P_SYM(p_find_me) = THIS_MODULE;

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -441,7 +441,7 @@ static inline int p_lkrg_counter_lock_val_read(p_lkrg_counter_lock *p_arg) {
 #endif
 
 #if defined(CONFIG_TRIM_UNUSED_KSYMS) && !defined(CONFIG_SECURITY_LKRG)
- #error "LKRG requires CONFIG_TRIM_UNUSED_KSYMS to be disabled if it should be built as an out-of-tree kernel module"
+ #error "LKRG requires CONFIG_TRIM_UNUSED_KSYMS to be disabled if it should be built as a kernel module"
 #endif
 
 #endif

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -391,6 +391,36 @@ static inline int p_lkrg_counter_lock_val_read(p_lkrg_counter_lock *p_arg) {
 /* End */
 
 /*
+ * siphash
+ */
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+   #include <linux/siphash.h>
+
+   typedef siphash_key_t p_global_siphash_key_t;
+
+   extern p_global_siphash_key_t p_global_siphash_key;
+
+   static inline void p_lkrg_set_siphash_key() {
+      p_global_siphash_key.key[0]  = (uint64_t)get_random_long();
+      p_global_siphash_key.key[1]  = (uint64_t)get_random_long();
+   }
+
+#else
+   typedef uint128_t p_global_siphash_key_t;
+
+   extern p_global_siphash_key_t p_global_siphash_key;
+
+   static inline void p_lkrg_set_siphash_key() {
+      p_global_siphash_key.p_low  = (uint64_t)get_random_long();
+      p_global_siphash_key.p_high = (uint64_t)get_random_long();
+   }
+
+#endif
+
+
+
+/*
  * LKRG modules
  */
 #include "modules/print_log/p_lkrg_print_log.h"               // printing, error and debug module

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -392,9 +392,10 @@ static inline int p_lkrg_counter_lock_val_read(p_lkrg_counter_lock *p_arg) {
 
 /*
  * siphash
+ * introduced into the linux kernel with 4.1.1 rc1 on 1/9/2017
  */
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 1)
    #include <linux/siphash.h>
 
    typedef siphash_key_t p_global_siphash_key_t;


### PR DESCRIPTION
### Description

I was hunting down a global oobr triggered in kasan. Tuned out the modprobe has to be run from `sudo -s` instead just using `sudo` only to make it work. The only noticeable trace is the error dumping to dmesg if it fails. I assume this happens if `kptr_restrict` is set and the user who runs `modprobe` has no `CP_SYSLOG` permissions. 

During the process I made a few changes which might be valuable:
* reflected the above situation to `README` 
* added some lines to remove static keywords `add-exports.sh`, otherwise my 6.x kernel refused to compile (using clang)
* added some checks to avoid hashes of zero sized sections so it's visible in debug log if this happens by setting the hash to 0xFFFFFFFF
* fixed `CONFIG_SECURITY_SELINUX` vs. `CONFIG_SECURITY_SELINUX_DEVELOP` which would enable `sel_write_enforce`
* fixes a typo in `P_LKRG_EXPLOIT_DETECTION_SECURTIY_PTRACE_ACCESS_H`
* fixed some types for clarification
* removed a sizeof as we can safely assume 8 for `uint64_t` and the next line shares this assumption by using `& 7`
* added a case 0 to the hash algorithm to satisfy clang and avoid warnings
* clarified a warning which I found to be misleading (I build in-tree, but as a module)

### How Has This Been Tested?
Tested the build a lot of times on multiple systems with different configuration

