### PR TITLE
CI: mainline: Change base URL

### DIFF
--- a/.github/workflows/ubuntu-kernel-daily.sh
+++ b/.github/workflows/ubuntu-kernel-daily.sh
@@ -8,6 +8,7 @@
 #
 
 baseurl="https://kernel.ubuntu.com/~kernel-ppa"
+baseurl="https://kernel.ubuntu.com"
 for listurl in \
 	"$baseurl/mainline/daily/" \
 	"$baseurl/mainline/"


### PR DESCRIPTION
https://kernel.ubuntu.com/~kernel-ppa/mainline/daily/ reporting:
```
  <title>301 Moved Permanently</title>
  <p>The document has moved <a
  href="https://kernel.ubuntu.com/mainline/daily/">here</a>.</p>
```
Fixes: https://github.com/lkrg-org/lkrg/issues/292

### Description
Base url changed.

### How Has This Been Tested?
Will be tested in this PR.

