### PR TITLE
kINT: Fix synchronization problem

### DIFF
--- a/src/modules/database/p_database.c
+++ b/src/modules/database/p_database.c
@@ -191,6 +191,7 @@ int p_create_database(void) {
 
    P_SYM_INIT(jump_label_mutex)
    P_SYM_INIT(text_mutex)
+   P_SYM_INIT(tracepoints_mutex)
 
    /*
     * First gather information about CPUs in the system - CRITICAL !!!

--- a/src/modules/database/p_database.h
+++ b/src/modules/database/p_database.h
@@ -205,6 +205,7 @@ static inline void p_text_section_lock(void) {
    mutex_lock(P_SYM(p_module_mutex));
    while (mutex_is_locked(P_SYM(p_jump_label_mutex)))
       schedule();
+   mutex_lock(P_SYM(p_tracepoints_mutex));
 #if defined(P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H)
    do {
       p_lkrg_counter_lock_lock(&p_static_call_spinlock, &p_text_flags);
@@ -225,6 +226,7 @@ static inline void p_text_section_unlock(void) {
 #if defined(P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H)
    p_lkrg_counter_lock_val_dec(&p_static_call_spinlock);
 #endif
+   mutex_unlock(P_SYM(p_tracepoints_mutex));
    /* Release the 'module_mutex' */
    mutex_unlock(P_SYM(p_module_mutex));
 #if defined(CONFIG_DYNAMIC_FTRACE)

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -237,6 +237,7 @@ typedef struct _p_lkrg_global_symbols_structure {
    pmd_t *(*p_mm_find_pmd)(struct mm_struct *mm, unsigned long address);
    struct mutex *p_jump_label_mutex;
    struct mutex *p_text_mutex;
+   struct mutex *p_tracepoints_mutex;
    struct text_poke_loc **p_tp_vec;
    int *p_tp_vec_nr;
 #if defined(CONFIG_DYNAMIC_DEBUG)


### PR DESCRIPTION
The reported problem with integrity verification on ARM64 (#269) is a result of a very tight race condition with tracepoints. Changes which simplify synchronization with JUMP_LABEL engine: f98da1b17c01c168ec163b0349327661adc9e38d
affected differently ARM64 platform which made such race possible. However, potentially the same race problem may exist on x86 and this commit fixes it and should address #269

### How Has This Been Tested?
I've run various stress manual tests on:
- ARM64: using Raspberry Pi 4 (under the kernel 6.5.0-1005-raspi)
- x86: using various kernels from Ubuntu 23.10 and 22.04.3, custom kernel 6.3.4 and CentOS 8 (kernel 4.18.0-240.15.1.el8_3.x86_64)

