### PR TITLE
Add support for RHEL 8.8

### DIFF
--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -62,7 +62,9 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0) || \
     defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
  #if !P_LKRG_KERNEL_HAS_VAR_LEN_JUMP_LABEL || \
-     (defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9,1))
+     (defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL) && \
+      RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9,1) && \
+      RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8,8))
 typedef struct _p_text_poke_loc {
     s32 rel_addr; /* addr := _stext + rel_addr */
     s32 rel32;


### PR DESCRIPTION
A new 'text_poke_loc' was backported to RHEL 8.8+. This commit brings the support for such kernels as well as addresses the #295 problem.


### How Has This Been Tested?
Tested on RHEL 9.1 (Alma), RHEL 9.0 (Alma), RHEL 8.7 (Alma), RHEL 8.8 (Alma) and RHEL 8.3 (CentOS)

