### PR TITLE
CI: mkosi-mainline: Support for 'noble' mainline kernels

### DIFF
--- a/.github/workflows/mkosi-mainline.yml
+++ b/.github/workflows/mkosi-mainline.yml
@@ -24,6 +24,12 @@ jobs:
                   sudo rm -f /dev/kvm
                   echo /usr/local/bin >> $GITHUB_PATH
 
+            - name: Install debootstrap from Ubuntu git
+              run: |
+                  sudo git clone --depth 1 https://git.launchpad.net/ubuntu/+source/debootstrap /debootstrap
+                  sudo chmod a+x /debootstrap/debootstrap
+                  sudo ln -s /debootstrap/debootstrap -t /usr/local/bin
+
             - name: Download mainline kernel from Kernel PPA
               run: .github/workflows/ubuntu-kernel-daily.sh
 


### PR DESCRIPTION
### Description

Ubuntu started to create mainline kernel packages for upcoming 'noble' release but jammy's (where CI runs) debootstrap knows nothing about it.

debootstrap fails with (though this is not visible in mkosi output):

    E: No such script: /usr/share/debootstrap/scripts/noble

Add Ubuntu's development debootstrap from their git. It's possible to run it from the git repo itself (as stated in their README). The repo cloned into `/debootstrap` so we don't need to set `DEBOOTSTRAP_DIR` and executable is symlinked to `/usr/local/bin` which we prepared earlier (and GA prepends it to `PATH`).

For the current bug it's not required to symlink `debootstrap` script because today we only need to update their `scripts` directory but this fuller update may be future proof.

Fixes: https://github.com/lkrg-org/lkrg/issues/303

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
GA run in fork .
