### PR TITLE
ci: docker-boot: Improve detection of kernel version

### DIFF
--- a/.github/workflows/docker-boot.sh
+++ b/.github/workflows/docker-boot.sh
@@ -35,7 +35,7 @@ WORKDIR /lkrg
 COPY . .
 RUN git clean -dxfq
 RUN DESTDIR= ./mkosi.build
-RUN depmod -a \$(cd /lib/modules; ls)
+RUN depmod -a \$(cd /lib/modules; ls | sort -V | tail -1)
 EOF
 
 # Convert Docker container into QEMU image (first extract rootfs).


### PR DESCRIPTION
### Description
Ubuntu starts to install linux-headers-generic
(linux-headers-5.15.0-102-generic) with /lib/modules/5.15.0-102-generic containing the `build` link, which confuses simple `ls` method version detection and later depmod call. Make kernel version detection similar to the other places.

Fixes: https://github.com/lkrg-org/lkrg/issues/332

### How Has This Been Tested?
https://github.com/vt-alt/lkrg/actions/runs/8747621184/job/24006360510