### PR TITLE
respect IRQ state

### DIFF
--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -76,7 +76,7 @@ LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instan
 //   struct inode *p_inode;
    struct p_ed_process *p_tmp;
    unsigned long p_flags;
-
+   struct task_struct *curr = current;
 /*
    p_inode = p_get_inode_from_task(current);
 
@@ -87,9 +87,9 @@ LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instan
 
    // Update process
    p_tasks_write_lock(&p_flags);
-   if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
+   if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(curr))) != NULL) {
       // This process is on the ED list - update information!
-      p_update_ed_process(p_tmp, current, 1);
+      p_update_ed_process(p_tmp, curr, 1);
 #ifdef P_LKRG_TASK_OFF_DEBUG
       p_debug_off_flag_reset(p_tmp, 40);
 #endif


### PR DESCRIPTION
### Description
On loaded SMP systems this patch introduce safe behavior while in disabled IRQ state. 


### How Has This Been Tested?
This prevent Oops and false-positive
`LKRG: ALERT: DETECT: Task: 'off' flag corruption for pid 5192, name kvm`
at least on latest kernel

