### PR TITLE
Make criticall section, while working with task_struct, safe again.

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -966,7 +966,10 @@ static inline void p_ed_is_off_off(struct p_ed_process *p_source, long p_val, in
    }
 }
 
+static unsigned long task_lock_flags;
 static inline void p_validate_off_flag(struct p_ed_process *p_source, long p_val, int *p_ret) {
+
+   struct task_struct *curr = p_source->p_ed_task.p_task;
 
    if (likely(p_val == p_global_cnt_cookie))
       return;
@@ -977,7 +980,10 @@ static inline void p_validate_off_flag(struct p_ed_process *p_source, long p_val
          break;
    }
 
+   spin_lock_irqsave(&curr->alloc_lock, task_lock_flags);
    p_ed_is_off_off(p_source, p_val, p_ret);
+   spin_unlock_irqrestore(&curr->alloc_lock, task_lock_flags);
+
 }
 
 #if P_OVL_OVERRIDE_SYNC_MODE

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -75,7 +75,6 @@ LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instan
 
 //   struct inode *p_inode;
    struct p_ed_process *p_tmp;
-   unsigned long p_flags;
 
 /*
    p_inode = p_get_inode_from_task(current);
@@ -86,7 +85,6 @@ LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instan
 */
 
    // Update process
-   p_tasks_write_lock(&p_flags);
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(current))) != NULL) {
       // This process is on the ED list - update information!
       p_update_ed_process(p_tmp, current, 1);
@@ -95,7 +93,6 @@ LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instan
 #endif
       p_reset_ed_flags(p_tmp);
    }
-   p_tasks_write_unlock(&p_flags);
 
 //   p_ed_enforce_validation();
 


### PR DESCRIPTION
### Description
<!--- Describe your changes -->
This is second attempt to fix bug in exploit detection engine of LKRG.
First attempt: https://github.com/lkrg-org/lkrg/pull/339 
Similar symptoms: https://github.com/lkrg-org/lkrg/issues/329
 
### How This Could Be Reproduced?
<!--- Please describe how you tested your changes. -->
To trigger the BUG the new process from kernel context could be spawned.
For example:

Set `lkrg.block_modules=1` and and ensure, that some modules like `netlink_diag af_packet_diag mptcp_diag unix_diag tcp_diag udp_diag raw_diag` aren't taint in the kernel.

1st terminal: `while true; do exec sh -c exit & done`
2nd terminal: `while true; do sudo ss -apn; done`

second command will trigger kernel to spawn modprobe, but since lkrg is blocking modules - it will be rejected.
This way we can increase chance to win the race, when:

1) we increase task refs cont and call p_ed_is_off_off()
2) the task somehow enter in the destruction procedure
3) we compare corrupted cookies and hit `if (unlikely(p_val != p_global_cnt_cookie))`
4) the task now totally destructed
5) we calling `p_ed_kill_task_by_task(p_source->p_ed_task.p_task);` for uninitialized memory instead of alive task.

then in `dmesg` output you would see something like:
```
[ 4103.670400] LKRG: ALERT: DETECT: Task: 'off' flag corruption for pid 439, name sh
[ 4103.671411] LKRG: ALERT: BLOCK: Task: Killing pid 0, name 
```
and, possible, an Oops.

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
After applying this patch - steps from above wouldn't trigger false-positives, and would not crash the kernel anymore.

At least on my setup.
