### PR TITLE
CI: mkosi: Fix the lack of gcc-13 for mainline builds

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -22,8 +22,7 @@ RootSize=4G
 [Packages]
 BuildPackages=
 	diffutils
-	gcc
-	make
+	dkms
 	linux-virtual
 Packages=
 	sysvbanner


### PR DESCRIPTION
### Description
Installing dkms should be generic enough to bring everything needed to build kernel modules.

This is not 100% solution since exact kernel version may still differ:

  $ make ...
  The kernel was built by: x86_64-linux-gnu-gcc-13 (Ubuntu 13.3.0-3ubuntu1) 13.3.0
  You are using:           gcc-13 (Ubuntu 13.3.0-4ubuntu1) 13.3.0

But this is best effort.

### How Has This Been Tested?
Tested on my GA account.

