### PR TITLE
Add support for JUMP_LABEL batch-mode feature for ARM64

### DIFF
--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -32,7 +32,11 @@ char p_arch_jump_label_transform_kretprobe_state = 0;
 p_lkrg_counter_lock p_jl_lock;
 
 static struct kretprobe p_arch_jump_label_transform_kretprobe = {
+#if defined(CONFIG_ARM64) && defined(HAVE_JUMP_LABEL_BATCH)
+    .kp.symbol_name = "arch_jump_label_transform_queue",
+#else
     .kp.symbol_name = "arch_jump_label_transform",
+#endif
     .handler = p_arch_jump_label_transform_ret,
     .entry_handler = p_arch_jump_label_transform_entry,
     .data_size = sizeof(struct p_arch_jump_label_transform_data),


### PR DESCRIPTION
ARM64 added support for JUMP_LABEL batch-mode feature. This commit adds support for it and addresses #351

### How Has This Been Tested?
Run it under Raspberry Pi 4 (under ALT Linux - thanks to @vt-alt ). I run it for couple of hours under the following condition:

screen 1: run the command `while true; do echo 1 > /sys/kernel/debug/tracing/events/enable && echo 0 > /sys/kernel/debug/tracing/events/enable; done` which enforces JUMP_LABEL batch mode
screen 2: run the command `while true; do sysctl lkrg.trigger=1; sleep 1; done` to enforce integrity validation.

More comprehensive tests are probably needed. However, it seems like that current logic works (at least for now).

