### PR TITLE
fix: debian/control: Add build-depends dh-dkms

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Vcs-Git: https://github.com/lkrg-org/lkrg.git
 Standards-Version: 4.5.1.1
 Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 13),
- dkms
+ dh-dkms
 
 Package: lkrg
 Architecture: all


### PR DESCRIPTION
### Description
According to Debian packaging guidelines, 'dh-dkms' should be added to the build dependencies.

### How Has This Been Tested?
Link: https://github.com/linuxdeepin/developer-center/issues/10661
