### PR TITLE
CI fixes for Centos 7 and ALT Sisyphus

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -4,17 +4,10 @@ on: [push, pull_request]
 jobs:
     build:
         runs-on: ubuntu-22.04
-        env:
-            ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
-            ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - image: centos:7
-                      run: |
-                          sed -i 's,^mirrorlist=,#,; s,^#baseurl=http://mirror\.centos\.org/centos/$releasever,baseurl=https://vault.centos.org/7.9.2009,' /etc/yum.repos.d/CentOS-Base.repo
-                          yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: almalinux:8
                       run: yum install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: rockylinux:8

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -24,7 +24,9 @@ jobs:
                     - image: fedora:latest
                       run: dnf install -y kernel-devel kernel gcc make elfutils-libelf-devel
                     - image: alt:sisyphus
-                      run: apt-get update; apt-get install -y kernel-headers-modules-un-def gcc make libelf-devel
+                      run: |
+                          apt-get update && apt-get install -y gcc make libelf-devel && \
+                          apt-get install -y kernel-headers-modules-mainline || apt-get install -y kernel-headers-modules-latest1
                     - image: registry.opensuse.org/opensuse/tumbleweed
                       run: zypper -n install -y gcc make kernel-default-devel awk
                     - image: registry.opensuse.org/opensuse/leap

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -24,13 +24,20 @@ jobs:
                 include:
                     - image: arm64v8/ubuntu:jammy
                       platform: linux/arm64
-                      packages: libelf-dev linux-headers-generic
+                      run: apt-get -y update && apt-get install -y git file gcc make  libelf-dev linux-headers-generic
                     - image: arm32v7/alt:latest
                       platform: linux/arm/v7
-                      packages: elfutils kernel-headers-modules-std-def
+                      run: apt-get -y update && apt-get install -y git file gcc make  elfutils kernel-headers-modules-std-def
                     - image: i386/ubuntu:bionic
                       platform: linux/386
-                      packages: libelf-dev linux-headers-generic
+                      run: apt-get -y update && apt-get install -y git file gcc make  libelf-dev linux-headers-generic
+                    - image: centos:7
+                      platform: linux/amd64
+                      run: |
+                          sed -i -e 's,^mirrorlist=,#,' \
+                                 -e 's,^#baseurl=http://mirror\.centos\.org/centos/\$releasever,baseurl=https://vault.centos.org/7.9.2009,' \
+                                /etc/yum.repos.d/CentOS-Base.repo && \
+                          yum install -y git file gcc make  kernel-devel kernel elfutils-libelf-devel
         steps:
             - uses: docker/setup-qemu-action@v2
             - uses: actions/checkout@v3
@@ -38,8 +45,7 @@ jobs:
               run: |
                   cat <<EOF >Dockerfile
                   FROM ${{ matrix.image }}
-                  RUN apt-get -y update && \
-                      apt-get install -y git file gcc make ${{ matrix.packages }}
+                  RUN ${{ matrix.run }}
                   WORKDIR /src
                   COPY . .
                   RUN git clean -dxfq


### PR DESCRIPTION
### Description
Fix CI for Centos 7 and ALT Sisyphus.

### How Has This Been Tested?
- Centos fix on my GA. 
- It seems that flt.altlinux.org have 1 day delay behind actual repo. Thus, the fix will start to work after 24 hours.