### PR TITLE
Some exploit detection cleanup

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1203,9 +1203,7 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
 
    /* Before leaving, verify current task */
    p_tasks_read_lock(&p_flags);
-   if (p_is_ed_task(current)) {
-      p_validate_task_f(current);
-   }
+   p_validate_task_f();
    p_tasks_read_unlock(&p_flags);
 
    return p_ret;
@@ -1417,35 +1415,26 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
    return p_killed ? -p_ret : p_ret;
 }
 
-int p_validate_task_f(void *p_arg) {
+void p_validate_task_f(void) {
 
-   int p_ret = P_LKRG_SUCCESS;
    struct p_ed_process *p_tmp;
-   struct task_struct *p_task = (struct task_struct *)p_arg;
+   struct task_struct *p_task = current;
 
-   rcu_read_lock();
-   get_task_struct(p_task);
+   if (!p_is_ed_task(p_task))
+      return;
 
    if ( (p_tmp = p_find_ed_by_pid(task_pid_nr(p_task))) == NULL) {
       // This process is not on the list!
       if (p_get_task_state(p_task) != TASK_DEAD) {
-         p_ret = P_LKRG_GENERAL_ERROR;
          p_print_log(P_LOG_WATCH, "Can't find in internal tracking list pid %u, name %s", task_pid_nr(p_task), p_task->comm);
       }
-      goto p_validate_task_out;
+      return;
    }
 
    if (p_cmp_tasks(p_tmp, p_task, 1) > 0) {
       // kill this process!
       p_ed_kill_task_by_task(p_task);
    }
-
-p_validate_task_out:
-
-   put_task_struct(p_task);
-   rcu_read_unlock();
-
-   return p_ret;
 }
 
 #ifdef CONFIG_SECURITY_SELINUX
@@ -1539,9 +1528,7 @@ void p_ed_validate_current(void) {
    if (!P_CTRL(p_pint_validate))
       return;
 
-   if (p_is_ed_task(current)) {
-      p_validate_task_f(current);
-   }
+   p_validate_task_f();
 }
 
 void p_ed_enforce_validation(void) {
@@ -1559,9 +1546,7 @@ void p_ed_enforce_validation(void) {
       case 2:
       case 1:
         p_tasks_read_lock(&p_flags);
-        if (p_is_ed_task(current)) {
-           p_validate_task_f(current);
-        }
+        p_validate_task_f();
         p_tasks_read_unlock(&p_flags);
         break;
 

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1128,9 +1128,7 @@ static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
    int p_ret;
    unsigned int p_err = 0;
    struct task_struct *p_ptmp, *p_tmp;
-   unsigned long p_flags;
 
-   p_tasks_read_lock(&p_flags);
    rcu_read_lock();
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    for_each_process_thread(p_ptmp, p_tmp) {
@@ -1162,7 +1160,6 @@ static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
    } while_each_thread(p_ptmp, p_tmp);
 #endif
    rcu_read_unlock();
-   p_tasks_read_unlock(&p_flags);
 
    return p_err;
 }

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1564,13 +1564,9 @@ unsigned int p_ed_enforce_validation_paranoid(void) {
 
    p_ed_pcfi_cpu(0);
 
-   if (!P_CTRL(p_pint_validate))
-      goto p_ed_enforce_validation_paranoid_globals;
-
    /* Validate processes and threads */
-   p_ret = p_iterate_lkrg_tasks_paranoid();
-
-p_ed_enforce_validation_paranoid_globals:
+   if (P_CTRL(p_pint_validate))
+      p_ret = p_iterate_lkrg_tasks_paranoid();
 
    /* Validate critical globals */
    p_ed_validate_globals();

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1123,10 +1123,8 @@ int p_remove_task_pid_f(pid_t p_arg) {
    return P_LKRG_SUCCESS;
 }
 
-static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
+static void p_dump_ed_tasks(void) {
 
-   int p_ret;
-   unsigned int p_err = 0;
    struct task_struct *p_ptmp, *p_tmp;
 
    rcu_read_lock();
@@ -1138,20 +1136,8 @@ static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
 #endif
 
       /* do not touch kernel threads or the global init */
-      if (!p_is_ed_task(p_tmp)) {
-         continue;
-      }
-
-      if ( (p_ret = p_func(p_tmp)) != 0) {
-         p_err++;
-         if (likely(p_ver)) {
-            if (spin_is_locked(&p_tmp->sighand->siglock)) {
-               p_regs_set_ip(task_pt_regs(p_tmp), -1);
-            } else {
-               p_ed_kill_task_by_task(p_tmp);
-            }
-         }
-      }
+      if (p_is_ed_task(p_tmp))
+         p_dump_task_f(p_tmp);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    }
@@ -1160,8 +1146,6 @@ static unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver) {
    } while_each_thread(p_ptmp, p_tmp);
 #endif
    rcu_read_unlock();
-
-   return p_err;
 }
 
 static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
@@ -1984,7 +1968,7 @@ int p_exploit_detection_init(void) {
    }
 
    // Dump processes and threads
-   p_iterate_processes(p_dump_task_f,0x0);
+   p_dump_ed_tasks();
 
    p_ret = P_LKRG_SUCCESS;
 

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -374,7 +374,6 @@ struct p_ed_global_variables {
 extern struct p_ed_global_variables p_ed_guard_globals;
 extern unsigned long p_pcfi_CPU_flags;
 
-//unsigned int p_iterate_processes(int (*p_func)(void *), char p_ver);
 int p_dump_task_f(void *p_arg);
 int p_remove_task_pid_f(pid_t p_arg);
 

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -393,7 +393,7 @@ void p_reset_ed_flags(struct p_ed_process *p_source);
 int p_verify_ovl_override_sync(struct p_ed_process *p_source);
 #endif
 
-int p_validate_task_f(void *p_arg);
+void p_validate_task_f(void);
 
 //void p_ed_pcfi_cpu(unsigned char p_kill);
 void p_ed_validate_current(void);


### PR DESCRIPTION
Most significantly, the small cleanups from this PR help eliminate further unnecessary {get|put}_task_struct() usage, which can be confusing and make it seem like there's a race on task_struct's lifetime when there isn't.