### PR TITLE
Move the CPU metadata dumping under a new config read lock

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,8 +3,10 @@ The following major changes have been made since 0.9.9:
  *) Overhaul locking of per-task shadow data, using finer-grain locks
  *) Improve performance of per-task shadow data lookups by making them lockless
  *) Fix several lethal race conditions involving SECCOMP_FILTER_FLAG_TSYNC
- *) Fix integrity violation misattribution to the wrong task when pint_enforce=0
+ *) Fix integrity violation misattribution to a wrong task when pint_enforce=0
  *) Fix several integrity violation race conditions when pint_enforce=0
+ *) Fix race condition on msr_validate sysctl changes as well as on transitions
+    between profile_validate=4 and others
  *) Support building against (but not yet loading into) Linux 6.15-rc1+
  *) Build and link the userspace logger tools with hardening flags, and pass
     distributions' RPM packaging hardening flags to the compiler and linker

--- a/src/modules/comm_channel/p_comm_channel.c
+++ b/src/modules/comm_channel/p_comm_channel.c
@@ -798,13 +798,13 @@ static int p_sysctl_msr_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
    int p_cpu;
    unsigned int p_tmp;
 
+   write_lock(&p_config_lock);
    p_tmp = P_CTRL(p_msr_validate);
    p_lkrg_open_rw();
    if ( (p_ret = proc_dointvec_minmax(p_table, p_write, p_buffer, p_len, p_pos)) == 0 && p_write) {
       if (P_CTRL(p_msr_validate) && !p_tmp) {
          P_CTRL(p_profile_validate) = 9;
          p_print_log(P_LOG_STATE, "Enabling 'msr_validate'");
-         spin_lock(&p_db_lock);
          memset(p_db.p_CPU_metadata_array,0,sizeof(p_CPU_metadata_hash_mem)*p_db.p_cpu.p_nr_cpu_ids);
          for_each_present_cpu(p_cpu) {
             if (cpu_online(p_cpu)) {
@@ -812,16 +812,14 @@ static int p_sysctl_msr_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
             }
          }
          p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-         spin_unlock(&p_db_lock);
       } else if (p_tmp && !P_CTRL(p_msr_validate)) {
          P_CTRL(p_profile_validate) = 9;
          p_print_log(P_LOG_STATE, "Disabling 'msr_validate'");
-         spin_lock(&p_db_lock);
          p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-         spin_unlock(&p_db_lock);
       }
    }
    p_lkrg_close_rw();
+   write_unlock(&p_config_lock);
 
    return p_ret;
 }
@@ -916,10 +914,10 @@ static int p_sysctl_profile_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
                   P_CTRL(p_umh_validate) = 0;   // Disabled
                   /* msr_validate */
                   if (P_CTRL(p_msr_validate)) {
-                     spin_lock(&p_db_lock);
+                     write_lock(&p_config_lock);
                      P_CTRL(p_msr_validate) = 0; // Disable
                      p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-                     spin_unlock(&p_db_lock);
+                     write_unlock(&p_config_lock);
                   }
 #if defined(CONFIG_X86)
                   /* smep_validate */
@@ -942,10 +940,10 @@ static int p_sysctl_profile_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
                   P_CTRL(p_umh_validate) = 1;   // Allow specific paths
                   /* msr_validate */
                   if (P_CTRL(p_msr_validate)) {
-                     spin_lock(&p_db_lock);
+                     write_lock(&p_config_lock);
                      P_CTRL(p_msr_validate) = 0; // Disable
                      p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-                     spin_unlock(&p_db_lock);
+                     write_unlock(&p_config_lock);
                   }
 #if defined(CONFIG_X86)
                   /* smep_validate */
@@ -984,10 +982,10 @@ static int p_sysctl_profile_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
                   P_CTRL(p_umh_validate) = 1;   // Allow specific paths
                   /* msr_validate */
                   if (P_CTRL(p_msr_validate)) {
-                     spin_lock(&p_db_lock);
+                     write_lock(&p_config_lock);
                      P_CTRL(p_msr_validate) = 0; // Disable
                      p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-                     spin_unlock(&p_db_lock);
+                     write_unlock(&p_config_lock);
                   }
 #if defined(CONFIG_X86)
                   /* smep_validate */
@@ -1026,10 +1024,10 @@ static int p_sysctl_profile_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
                   P_CTRL(p_umh_validate) = 1;   // Allow specific paths
                   /* msr_validate */
                   if (P_CTRL(p_msr_validate)) {
-                     spin_lock(&p_db_lock);
+                     write_lock(&p_config_lock);
                      P_CTRL(p_msr_validate) = 0; // Disable
                      p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-                     spin_unlock(&p_db_lock);
+                     write_unlock(&p_config_lock);
                   }
 #if defined(CONFIG_X86)
                   /* smep_validate */
@@ -1068,7 +1066,7 @@ static int p_sysctl_profile_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
                   P_CTRL(p_umh_validate) = 2;   // Full lock-down
                   /* msr_validate */
                   if (!P_CTRL(p_msr_validate)) {
-                     spin_lock(&p_db_lock);
+                     write_lock(&p_config_lock);
                      P_CTRL(p_msr_validate) = 1; // Enable
                      memset(p_db.p_CPU_metadata_array,0,sizeof(p_CPU_metadata_hash_mem)*p_db.p_cpu.p_nr_cpu_ids);
                      for_each_present_cpu(p_cpu) {
@@ -1077,7 +1075,7 @@ static int p_sysctl_profile_validate(P_STRUCT_CTL_TABLE *p_table, int p_write,
                         }
                      }
                      p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
-                     spin_unlock(&p_db_lock);
+                     write_unlock(&p_config_lock);
                   }
 #if defined(CONFIG_X86)
                   /* smep_validate */

--- a/src/modules/database/CPU.c
+++ b/src/modules/database/CPU.c
@@ -168,6 +168,7 @@ int p_cpu_online_action(unsigned int p_cpu) {
 
    p_text_section_lock();
    spin_lock(&p_db_lock);
+   read_lock(&p_config_lock);
 
    smp_call_function_single(p_cpu,p_dump_CPU_metadata,p_db.p_CPU_metadata_array,true);
 
@@ -186,6 +187,7 @@ int p_cpu_online_action(unsigned int p_cpu) {
       p_cpu_rehash("online");
    }
 
+   read_unlock(&p_config_lock);
    /* God mode off ;) */
 //   spin_unlock_irqrestore(&p_db_lock,p_db_flags);
    spin_unlock(&p_db_lock);
@@ -200,6 +202,7 @@ int p_cpu_dead_action(unsigned int p_cpu) {
 
    p_text_section_lock();
    spin_lock(&p_db_lock);
+   read_lock(&p_config_lock);
 
    p_db.p_CPU_metadata_array[p_cpu].p_cpu_online = P_CPU_OFFLINE;
 
@@ -226,6 +229,7 @@ int p_cpu_dead_action(unsigned int p_cpu) {
       p_cpu_rehash("offline");
    }
 
+   read_unlock(&p_config_lock);
    /* God mode off ;) */
 //   spin_unlock_irqrestore(&p_db_lock,p_db_flags);
    spin_unlock(&p_db_lock);

--- a/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
+++ b/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
@@ -38,6 +38,7 @@ static struct kretprobe p_switch_idt_kretprobe = {
 int p_switch_idt_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    spin_lock(&p_db_lock);
+   read_lock(&p_config_lock);
 
    /* A dump_stack() here will give a stack backtrace */
    return 0;
@@ -53,6 +54,7 @@ int p_switch_idt_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    smp_call_function_single(smp_processor_id(),p_dump_CPU_metadata,p_db.p_CPU_metadata_array,true);
    p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
 
+   read_unlock(&p_config_lock);
    spin_unlock(&p_db_lock);
 
    return 0;

--- a/src/modules/integrity_timer/p_integrity_timer.h
+++ b/src/modules/integrity_timer/p_integrity_timer.h
@@ -40,6 +40,7 @@ void p_offload_cache_delete(void);
 extern struct timer_list p_timer;
 extern unsigned int p_manual;
 extern spinlock_t p_db_lock;
+extern rwlock_t p_config_lock;
 extern unsigned long p_db_flags;
 extern struct kmem_cache *p_offload_cache;
 

--- a/src/modules/kmod/p_kmod_notifier.c
+++ b/src/modules/kmod/p_kmod_notifier.c
@@ -101,10 +101,12 @@ static int p_module_event_notifier(struct notifier_block *p_this, unsigned long 
 //   if (p_tmp->state == MODULE_STATE_GOING) { <- Linux kernel bug - might not update state value :(
    if (p_event == MODULE_STATE_GOING) {
 
+      read_lock(&p_config_lock);
       p_read_cpu_lock();
       on_each_cpu(p_dump_CPU_metadata,p_db.p_CPU_metadata_array,true);
       p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
       p_read_cpu_unlock();
+      read_unlock(&p_config_lock);
 
       /*
        * Now recalculate modules information in database!
@@ -173,10 +175,12 @@ static int p_module_event_notifier(struct notifier_block *p_this, unsigned long 
 //      if (p_tmp->state == MODULE_STATE_LIVE) { <- Linux kernel bug - might not update state value :(
       if (p_event == MODULE_STATE_LIVE) {
 
+         read_lock(&p_config_lock);
          p_read_cpu_lock();
          on_each_cpu(p_dump_CPU_metadata,p_db.p_CPU_metadata_array,true);
          p_db.p_CPU_metadata_hashes = hash_from_CPU_data(p_db.p_CPU_metadata_array);
          p_read_cpu_unlock();
+         read_unlock(&p_config_lock);
 
          /*
           * Now recalculate modules information in database! Since blocking module is disabled


### PR DESCRIPTION
and acquire the lock for writing on lkrg.msr_validate changes, which affect whether MSRs are included in the computed hash value.

Fixes #370

### How Has This Been Tested?

I am testing with:

```shell
while :; do sysctl lkrg.msr_validate=1; sysctl lkrg.msr_validate=0; done
```

I also trigger some coredumps in a loop, as this was causing softlocks with my previous attempts at fixing this issue (when I tried acquiring `p_db_lock`).