### PR TITLE
Fix ed_task_cache cleanup on failed LKRG initialization

### DIFF
--- a/src/modules/exploit_detection/ed_task_tree.c
+++ b/src/modules/exploit_detection/ed_task_tree.c
@@ -329,6 +329,9 @@ void destroy_ed_task_cache(void)
 {
 	int i;
 
+	if (!ed_task_cache)
+		return;
+
 	/* Flush all free_ed_task_rcu() callbacks */
 	rcu_barrier();
 
@@ -336,4 +339,6 @@ void destroy_ed_task_cache(void)
 	for (i = 0; i < RB_HASH_SIZE; i++)
 		free_one_tree(&ed_hash_tbl[i]);
 	kmem_cache_destroy(ed_task_cache);
+
+	ed_task_cache = NULL;
 }

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1923,7 +1923,6 @@ int p_ed_pcfi_validate_sp(struct task_struct *p_task, struct p_ed_process *p_ori
 
 int p_exploit_detection_init(void) {
 
-   int p_ret;
    const struct p_functions_hooks *p_fh_it;
 
    p_global_off_cookie = (unsigned long)get_random_long();
@@ -1935,14 +1934,12 @@ int p_exploit_detection_init(void) {
 
    if (p_ed_pcfi_cache_init()) {
       p_print_log(P_LOG_FATAL, "Can't initialize pCFI cache");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_exploit_detection_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    if (p_ed_wq_valid_cache_init()) {
       p_print_log(P_LOG_FATAL, "Can't initialize cache for data integrity WQ");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_exploit_detection_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    P_SYM_INIT(__kernel_text_address)
@@ -1957,8 +1954,7 @@ int p_exploit_detection_init(void) {
 #ifdef P_SELINUX_VERIFY
    if (p_selinux_state_init()) {
       p_print_log(P_LOG_FATAL, "Can't initialize SELinux");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_exploit_detection_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 #elif defined(CONFIG_GCC_PLUGIN_RANDSTRUCT)
    p_print_log(P_LOG_ISSUE, "Can't enforce SELinux validation (CONFIG_GCC_PLUGIN_RANDSTRUCT detected)");
@@ -1972,14 +1968,11 @@ int p_exploit_detection_init(void) {
 
    if (init_ed_task_cache()) {
       p_print_log(P_LOG_FATAL, "Can't initialize task cache");
-      p_ret = P_LKRG_GENERAL_ERROR;
-      goto p_exploit_detection_init_out;
+      return P_LKRG_GENERAL_ERROR;
    }
 
    // Dump processes and threads
    p_dump_ed_tasks();
-
-   p_ret = P_LKRG_SUCCESS;
 
    for (p_fh_it = p_functions_hooks_array; p_fh_it->name != NULL; p_fh_it++) {
       if (p_fh_it->install(p_fh_it->is_isra_safe)) {
@@ -1988,14 +1981,11 @@ int p_exploit_detection_init(void) {
              continue;
          }
          p_print_log(P_LOG_FATAL, "Can't hook %s", p_fh_it->name);
-         p_ret = P_LKRG_GENERAL_ERROR;
-         break;
+         return P_LKRG_GENERAL_ERROR;
       }
    }
 
-p_exploit_detection_init_out:
-
-   return p_ret;
+   return P_LKRG_SUCCESS;
 
 p_sym_error:
    return P_LKRG_GENERAL_ERROR;

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1989,7 +1989,6 @@ int p_exploit_detection_init(void) {
          }
          p_print_log(P_LOG_FATAL, "Can't hook %s", p_fh_it->name);
          p_ret = P_LKRG_GENERAL_ERROR;
-         p_exploit_detection_exit();
          break;
       }
    }


### PR DESCRIPTION
### Description
This fixes #378.

### How Has This Been Tested?
The first commit here I tested by re-running the tests I mentioned in #378. The second commit is untested yet, I'll test it in the same way now.