### PR TITLE
Make kprobes testing via LKRG's own dummy function hooking optional

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ The following major changes have been made since 0.9.9:
  *) Fix several integrity violation race conditions when pint_enforce=0
  *) Fix race condition on msr_validate sysctl changes as well as on transitions
     between profile_validate=4 and others
+ *) Make kprobes testing via LKRG's own dummy function hooking optional (works
+    around issue seen on recent Gentoo)
  *) Support building against (but not yet loading into) Linux 6.15-rc1+
  *) Build and link the userspace logger tools with hardening flags, and pass
     distributions' RPM packaging hardening flags to the compiler and linker

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
@@ -51,6 +51,9 @@ int lkrg_verify_kprobes(void) {
 
    int p_ret = 0, ret = -1;
 
+   if (!p_lkrg_dummy_kretprobe_state)
+      return 0;
+
    /* Verify kprobes now */
    if ( (ret = lkrg_dummy(0)) != 3) {
       /* I'm hacked! ;( */

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -418,10 +418,8 @@ static int __init p_lkrg_register(void) {
     */
 
    /* Register kprobes hooks necessary to verify kprobes itself */
-   if (p_install_lkrg_dummy_hook(0)) {
-      p_print_log(P_LOG_FATAL, "Can't hook 'lkrg_dummy'");
-      return P_LKRG_GENERAL_ERROR;
-   }
+   if (p_install_lkrg_dummy_hook(0))
+      p_print_log(P_LOG_ISSUE, "Can't hook 'lkrg_dummy'");
 
    /* Verify kprobes now */
    if (lkrg_verify_kprobes()) {


### PR DESCRIPTION
Works around #364 seen on recent Gentoo.

### Description
This turns inability to hook the dummy function from FATAL to ISSUE, and lets LKRG loading proceed without kprobes testing.

### How Has This Been Tested?
As I was unable to reproduce the original issue, I simulated it by temporarily renaming the function attempted to be hooked. I enabled `log_level=4` and confirmed that the log records are as expected for both being able to hook (and use) the function and otherwise (when I rename it).