### PR TITLE
Support new kernels without hook-able {override,revert}_creds()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 The following major changes have been made since 0.9.9:
 
+ *) Support Linux 6.14+ where we can't hook {override,revert}_creds() anymore,
+    by limiting detection of cred pointer overwrite attacks on those kernels
  *) Overhaul locking of per-task shadow data, using finer-grain locks
  *) Improve performance of per-task shadow data lookups by making them lockless
  *) Fix several lethal race conditions involving SECCOMP_FILTER_FLAG_TSYNC
@@ -10,7 +12,6 @@ The following major changes have been made since 0.9.9:
     between profile_validate=4 and others
  *) Make kprobes testing via LKRG's own dummy function hooking optional (works
     around issue seen on recent Gentoo)
- *) Support building against (but not yet loading into) Linux 6.15-rc1+
  *) Build and link the userspace logger tools with hardening flags, and pass
     distributions' RPM packaging hardening flags to the compiler and linker
  *) lkrg-logctl: Support and report continuation lines (an extra one-character

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 The following major changes have been made since 0.9.9:
 
- *) Support Linux 6.14+ where we can't hook {override,revert}_creds() anymore,
-    by limiting detection of cred pointer overwrite attacks on those kernels
+ *) Support Linux 6.13+ by not hooking {override,revert}_creds() anymore, and
+    limiting detection of cred pointer overwrite attacks on those kernels
  *) Overhaul locking of per-task shadow data, using finer-grain locks
  *) Improve performance of per-task shadow data lookups by making them lockless
  *) Fix several lethal race conditions involving SECCOMP_FILTER_FLAG_TSYNC

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -276,6 +276,7 @@ static const struct p_functions_hooks {
    },
  #endif /* P_SYSCALL_LAYOUT_4_17 */
 #endif /* CONFIG_X86_X32 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
    { "override_creds",
      p_install_override_creds_hook,
      p_uninstall_override_creds_hook,
@@ -290,6 +291,7 @@ static const struct p_functions_hooks {
      NULL,
      0
    },
+#endif
    /* Namespaces. */
    { "sys_setns",
      p_install_sys_setns_hook,
@@ -1350,7 +1352,25 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
    /* Get reference to real_cred */
    get_cred(p_current_real_cred);
 
-   if (p_orig->p_ed_task.p_cred_ptr != p_current_cred) {
+   /*
+    * Pre-check for *cred pointer corruption and report it if the credentials
+    * also differ, but do not report those credentials differences just yet.
+    * This may be weird, but it was preserved over code refactorings for now so
+    * that no unintentional functional changes were made in those.  We may
+    * reconsider it separately.
+    *
+    * We can no longer hook override_creds() on Linux 6.14+, so we infer that
+    * it's probably in effect through only the cred pointer being different,
+    * but real_cred staying unchanged.  If both have changed, commit_creds()
+    * may have been used.  Here we assume that uses of override_creds() are
+    * legitimate, but uses of commit_creds() are not (we set our "off" flag on
+    * the legitimate ones, so would not reach this function in those cases).
+    */
+   if (p_orig->p_ed_task.p_cred_ptr != p_current_cred
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+      && p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred
+#endif
+      ) {
       if (p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x0)) {
          P_CMP_PTR(p_orig->p_ed_task.p_cred_ptr, p_current_cred, "cred")
       }
@@ -1362,7 +1382,13 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
       }
    }
 
-   p_ret += p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x1);
+   /*
+    * Now (re-)check the credentials and report any differences.
+    */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+   if (p_orig->p_ed_task.p_cred_ptr == p_current_cred || p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred)
+#endif
+      p_ret += p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x1);
    p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x1);
 
    /* Namespaces */

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -276,7 +276,7 @@ static const struct p_functions_hooks {
    },
  #endif /* P_SYSCALL_LAYOUT_4_17 */
 #endif /* CONFIG_X86_X32 */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
    { "override_creds",
      p_install_override_creds_hook,
      p_uninstall_override_creds_hook,
@@ -1359,15 +1359,15 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
     * that no unintentional functional changes were made in those.  We may
     * reconsider it separately.
     *
-    * We can no longer hook override_creds() on Linux 6.14+, so we infer that
-    * it's probably in effect through only the cred pointer being different,
-    * but real_cred staying unchanged.  If both have changed, commit_creds()
-    * may have been used.  Here we assume that uses of override_creds() are
+    * We no longer hook override_creds() on Linux 6.13+, so we infer that an
+    * override is in effect through only the cred pointer being different, but
+    * real_cred staying unchanged.  If both have changed, commit_creds() may
+    * have been used.  Here we assume that uses of override_creds*() are
     * legitimate, but uses of commit_creds() are not (we set our "off" flag on
     * the legitimate ones, so would not reach this function in those cases).
     */
    if (p_orig->p_ed_task.p_cred_ptr != p_current_cred
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
       && p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred
 #endif
       ) {
@@ -1385,7 +1385,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
    /*
     * Now (re-)check the credentials and report any differences.
     */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
    if (p_orig->p_ed_task.p_cred_ptr == p_current_cred || p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred)
 #endif
       p_ret += p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x1);

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -22,6 +22,8 @@
 
 #include "../../../../../p_lkrg_main.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+
 char p_override_creds_kretprobe_state = 0;
 
 static struct kretprobe p_override_creds_kretprobe = {
@@ -73,3 +75,5 @@ notrace int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *
 
 
 GENERATE_INSTALL_FUNC(override_creds)
+
+#endif

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -22,7 +22,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
 char p_override_creds_kretprobe_state = 0;
 

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
@@ -23,7 +23,7 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_OVERRIDE_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_OVERRIDE_CREDS_H
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
 /* per-instance private data */
 struct p_override_creds_data {

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
@@ -23,6 +23,8 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_OVERRIDE_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_OVERRIDE_CREDS_H
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+
 /* per-instance private data */
 struct p_override_creds_data {
     ktime_t entry_stamp;
@@ -33,4 +35,5 @@ int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
 int p_install_override_creds_hook(int p_isra);
 void p_uninstall_override_creds_hook(void);
 
+#endif
 #endif

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -21,6 +21,8 @@
 
 #include "../../../../../p_lkrg_main.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+
 char p_revert_creds_kretprobe_state = 0;
 
 static struct kretprobe p_revert_creds_kretprobe = {
@@ -65,3 +67,5 @@ notrace int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_
 
 
 GENERATE_INSTALL_FUNC(revert_creds)
+
+#endif

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -21,7 +21,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
 char p_revert_creds_kretprobe_state = 0;
 

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
@@ -22,7 +22,7 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_REVERT_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_REVERT_CREDS_H
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
 /* per-instance private data */
 struct p_revert_creds_data {

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
@@ -22,6 +22,8 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_REVERT_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_REVERT_CREDS_H
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+
 /* per-instance private data */
 struct p_revert_creds_data {
     ktime_t entry_stamp;
@@ -32,4 +34,5 @@ int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
 int p_install_revert_creds_hook(int p_isra);
 void p_uninstall_revert_creds_hook(void);
 
+#endif
 #endif


### PR DESCRIPTION
### Description
This works by not validating the effective credentials when the pointer differs, which may indicate that override_creds() is in effect or that the pointer was overwritten in an attack.  So with this workaround we'll be blind to cred pointer overwrite attacks, but would still detect overwrites of the creds themselves if the pointer is kept intact.  We should also still detect exploits' use of commit_creds() as that function also replaces real_cred, which we continue to validate in all cases.

Works around #371

### How Has This Been Tested?
On Arch Linux with 6.14.3-arch1-1, running SUID programs such as `su` and `passwd` on the Arch system itself, as well as in a Docker container with Alpine Linux. Without the relaxed validation, all of these triggered alerts and the commands were killed. With this PR's changes, they just work correctly and nothing appears in the logs.