### PR TITLE
Fix race condition (possible NULL dereference) with namespace validation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ The following major changes have been made since 0.9.9:
  *) Fix several lethal race conditions involving SECCOMP_FILTER_FLAG_TSYNC
  *) Fix integrity violation misattribution to a wrong task when pint_enforce=0
  *) Fix several integrity violation race conditions when pint_enforce=0
+ *) Fix race condition (possible NULL dereference) with namespace validation
  *) Fix race condition on msr_validate sysctl changes as well as on transitions
     between profile_validate=4 and others
  *) Support building against (but not yet loading into) Linux 6.15-rc1+

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -523,19 +523,34 @@ notrace void p_update_ed_process(struct p_ed_process *p_source, struct task_stru
    if (p_stack)
       p_source->p_ed_task.p_stack                 = p_task->stack;
    /* Namespaces */
-   p_source->p_ed_task.p_nsproxy                  = p_task->nsproxy;
-   p_source->p_ed_task.p_ns.uts_ns                = p_task->nsproxy->uts_ns;
-   p_source->p_ed_task.p_ns.ipc_ns                = p_task->nsproxy->ipc_ns;
-   p_source->p_ed_task.p_ns.mnt_ns                = p_task->nsproxy->mnt_ns;
+   /*
+    * A comment in <linux/nsproxy.h> documents "the namespaces access rules",
+    * which allow reading current task's namespaces without precautions, but
+    * another task's with task_lock() and check for "nsproxy != NULL".  We also
+    * worry about potential deadlocks, so we use spin_trylock() instead and
+    * skip our namespace validation if we couldn't acquire a lock.  We do the
+    * same here (update) and again further down this source file (validation).
+    */
+   if (p_task == current || spin_trylock(&p_task->alloc_lock)) {
+      p_source->p_ed_task.p_nsproxy               = p_task->nsproxy;
+      if (p_source->p_ed_task.p_nsproxy) {
+         p_source->p_ed_task.p_ns.uts_ns          = p_task->nsproxy->uts_ns;
+         p_source->p_ed_task.p_ns.ipc_ns          = p_task->nsproxy->ipc_ns;
+         p_source->p_ed_task.p_ns.mnt_ns          = p_task->nsproxy->mnt_ns;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,11,0)
-   p_source->p_ed_task.p_ns.pid_ns_for_children   = p_task->nsproxy->pid_ns_for_children;
+         p_source->p_ed_task.p_ns.pid_ns_for_children = p_task->nsproxy->pid_ns_for_children;
 #else
-   p_source->p_ed_task.p_ns.pid_ns                = p_task->nsproxy->pid_ns;
+         p_source->p_ed_task.p_ns.pid_ns          = p_task->nsproxy->pid_ns;
 #endif
-   p_source->p_ed_task.p_ns.net_ns                = p_task->nsproxy->net_ns;
+         p_source->p_ed_task.p_ns.net_ns          = p_task->nsproxy->net_ns;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-   p_source->p_ed_task.p_ns.cgroup_ns             = p_task->nsproxy->cgroup_ns;
+         p_source->p_ed_task.p_ns.cgroup_ns       = p_task->nsproxy->cgroup_ns;
 #endif
+      }
+      if (p_task != current)
+         spin_unlock(&p_task->alloc_lock);
+   } else
+      p_source->p_ed_task.p_nsproxy = NULL;
    /* Creds */
    p_dump_creds(&p_source->p_ed_task.p_cred, p_source->p_ed_task.p_cred_ptr);
    p_dump_creds(&p_source->p_ed_task.p_real_cred, p_source->p_ed_task.p_real_cred_ptr);
@@ -1351,19 +1366,25 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, struct task_struct *p_curren
    p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x1);
 
    /* Namespaces */
-   P_CMP_PTR(p_orig->p_ed_task.p_nsproxy, p_current->nsproxy, P_NS_ESCAPE "nsproxy")
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.uts_ns, p_current->nsproxy->uts_ns, P_NS_ESCAPE "uts_ns")
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.ipc_ns, p_current->nsproxy->ipc_ns, P_NS_ESCAPE "ipc_ns")
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.mnt_ns, p_current->nsproxy->mnt_ns, P_NS_ESCAPE "mnt_ns")
+   if (p_orig->p_ed_task.p_nsproxy && (p_current == current || spin_trylock(&p_current->alloc_lock))) {
+      if (p_current->nsproxy) {
+         P_CMP_PTR(p_orig->p_ed_task.p_nsproxy, p_current->nsproxy, P_NS_ESCAPE "nsproxy")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.uts_ns, p_current->nsproxy->uts_ns, P_NS_ESCAPE "uts_ns")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.ipc_ns, p_current->nsproxy->ipc_ns, P_NS_ESCAPE "ipc_ns")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.mnt_ns, p_current->nsproxy->mnt_ns, P_NS_ESCAPE "mnt_ns")
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,11,0)
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.pid_ns_for_children, p_current->nsproxy->pid_ns_for_children, P_NS_ESCAPE "pid_ns_for_children")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.pid_ns_for_children, p_current->nsproxy->pid_ns_for_children, P_NS_ESCAPE "pid_ns_for_children")
 #else
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.pid_ns, p_current->nsproxy->pid_ns, P_NS_ESCAPE "pid_ns")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.pid_ns, p_current->nsproxy->pid_ns, P_NS_ESCAPE "pid_ns")
 #endif
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.net_ns, p_current->nsproxy->net_ns, P_NS_ESCAPE "net_ns")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.net_ns, p_current->nsproxy->net_ns, P_NS_ESCAPE "net_ns")
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-   P_CMP_PTR(p_orig->p_ed_task.p_ns.cgroup_ns, p_current->nsproxy->cgroup_ns, P_NS_ESCAPE "cgroup_ns")
+         P_CMP_PTR(p_orig->p_ed_task.p_ns.cgroup_ns, p_current->nsproxy->cgroup_ns, P_NS_ESCAPE "cgroup_ns")
 #endif
+      }
+      if (p_current != current)
+         spin_unlock(&p_current->alloc_lock);
+   }
 
 #if defined(CONFIG_SECCOMP)
    /* Seccomp */


### PR DESCRIPTION
Fixes #375

### Description

A comment in <linux/nsproxy.h> documents "the namespaces access rules", which allow reading current task's namespaces without precautions, but another task's with task_lock() and check for "nsproxy != NULL".  We also worry about potential deadlocks, so we use spin_trylock() instead and skip our namespace validation if we couldn't acquire a lock.  We do the same on update and validation.

### How Has This Been Tested?

With this command, which previously triggered the issue and now does not (so far):

```
while :; do sysctl lkrg.trigger=1; sysctl lkrg.msr_validate=0; sysctl lkrg.trigger=1; sysctl lkrg.msr_validate=1; dmesg | tail -100 | fgrep -v LKRG; done
```

also by adding this hack:

```c
if (uid_eq(p_orig->p_ed_task.p_cred.euid, KUIDT_INIT(666))) p_orig->p_ed_task.p_ns.net_ns++;
```

and making sure this corruption is detected for a task with that euid. In other words, testing that we're not always skipping namespace validation.