### PR TITLE
UMH: Allow "off" to be set a second time

### DIFF
--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -84,6 +84,26 @@ int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs 
       goto p_call_usermodehelper_entry_not_allowed;
    }
    if ((p_tmp = ed_task_lock_current())) {
+      /*
+       * Dirty hack to allow "off" to be set a second time from our hook of
+       * security_bprm_committing_creds().
+       *
+       * We do this before rather than after p_set_ed_process_off() here to
+       * work around known glitching where we'd be accessing a wrong ed task
+       * record here (as well as later).
+       *
+       * These hacks force p_set_ed_process_off() to take the "override" path
+       * both here and in the second call (from the later hook), so that it
+       * doesn't conflict with "off" possibly already being set for the task.
+       *
+       * FIXME: Figure out and fix the glitch, so that we'd access the right
+       * task record here, then at least move the flag_sync_thread++ to after
+       * p_set_ed_process_off() and maybe also rename it to reflect it's not
+       * only for seccomp, or alternatively stop setting "off" here (which may
+       * then be unneeded because call_usermodehelper_exec_async() itself only
+       * updates the capability sets, which we don't yet track).
+       */
+      p_tmp->p_ed_task.p_sec.flag_sync_thread++;
       // This process is on the ED list - set temporary 'disable' flag!
       p_set_ed_process_off(p_tmp);
       ed_task_unlock(p_tmp);


### PR DESCRIPTION
### Description

Allow `off` to be set a second time. First from our hook of `call_usermodehelper_exec_async` and then also from our hook of `security_bprm_committing_creds`.  Without this hack, the latter would falsely detect `off` flag corruption due to our "`off` most be off" check.

Works around #385

### How Has This Been Tested?

By multiple reboots of the bare metal system where the issue was almost reliably reproducible. With this change, the issue is not seen on that system anymore.