### PR TITLE
Hooking: Switch many hooks to simple kprobes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ The following major changes have been made since 0.9.9:
 
  *) Support Linux 6.13+ by not hooking {override,revert}_creds() anymore, and
     limiting detection of cred pointer overwrite attacks on those kernels
+ *) Switch many hooks from kretprobes to simple kprobes for greater reliability
+    and improved performance
  *) Overhaul locking of per-task shadow data, using finer-grain locks
  *) Improve performance of per-task shadow data lookups by making them lockless
  *) Fix several lethal race conditions involving SECCOMP_FILTER_FLAG_TSYNC

--- a/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.c
+++ b/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.c
@@ -35,7 +35,6 @@ static struct kretprobe p_ftrace_enable_sysctl_kretprobe = {
     .kp.symbol_name = "ftrace_enable_sysctl",
     .handler = p_ftrace_enable_sysctl_ret,
     .entry_handler = p_ftrace_enable_sysctl_entry,
-    .data_size = sizeof(struct p_ftrace_enable_sysctl_data),
 };
 
 notrace int p_ftrace_enable_sysctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.c
+++ b/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.c
@@ -29,62 +29,23 @@
 
 #if defined(P_LKRG_FTRACE_ENABLE_SYSCTL_H)
 
-char p_ftrace_enable_sysctl_kretprobe_state = 0;
+#include "../../../exploit_detection/syscalls/p_install.h"
 
-static struct kretprobe p_ftrace_enable_sysctl_kretprobe = {
-    .kp.symbol_name = "ftrace_enable_sysctl",
-    .handler = p_ftrace_enable_sysctl_ret,
-    .entry_handler = p_ftrace_enable_sysctl_entry,
-};
-
-notrace int p_ftrace_enable_sysctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static notrace int p_ftrace_enable_sysctl_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    p_regs_set_arg2(p_regs, 0x0);
 
    return 0;
 }
 
+static struct lkrg_probe p_ftrace_enable_sysctl_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "ftrace_enable_sysctl",
+    .kp.pre_handler = p_ftrace_enable_sysctl_entry,
+  }
+};
 
-notrace int p_ftrace_enable_sysctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
-
-   return 0;
-}
-
-
-int p_install_ftrace_enable_sysctl_hook(void) {
-
-   int p_tmp;
-
-   p_ftrace_enable_sysctl_kretprobe.maxactive = p_get_kprobe_maxactive();
-   if ( (p_tmp = register_kretprobe(&p_ftrace_enable_sysctl_kretprobe)) != 0) {
-      p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
-                  p_ftrace_enable_sysctl_kretprobe.kp.symbol_name,
-                  p_tmp);
-      return P_LKRG_GENERAL_ERROR;
-   }
-   p_print_log(P_LOG_WATCH, "Planted [kretprobe] <%s> at: 0x%lx",
-               p_ftrace_enable_sysctl_kretprobe.kp.symbol_name,
-               (unsigned long)p_ftrace_enable_sysctl_kretprobe.kp.addr);
-   p_ftrace_enable_sysctl_kretprobe_state = 1;
-
-   return P_LKRG_SUCCESS;
-}
-
-
-void p_uninstall_ftrace_enable_sysctl_hook(void) {
-
-   if (!p_ftrace_enable_sysctl_kretprobe_state) {
-      p_print_log(P_LOG_WATCH, "[kretprobe] <%s> at 0x%lx is NOT installed",
-                  p_ftrace_enable_sysctl_kretprobe.kp.symbol_name,
-                  (unsigned long)p_ftrace_enable_sysctl_kretprobe.kp.addr);
-   } else {
-      unregister_kretprobe(&p_ftrace_enable_sysctl_kretprobe);
-      p_print_log(P_LOG_WATCH, "Removing [kretprobe] <%s> at 0x%lx nmissed[%d]",
-                  p_ftrace_enable_sysctl_kretprobe.kp.symbol_name,
-                  (unsigned long)p_ftrace_enable_sysctl_kretprobe.kp.addr,
-                  p_ftrace_enable_sysctl_kretprobe.nmissed);
-      p_ftrace_enable_sysctl_kretprobe_state = 0;
-   }
-}
+GENERATE_INSTALL_FUNC(ftrace_enable_sysctl)
 
 #endif

--- a/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.h
+++ b/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.h
@@ -30,11 +30,9 @@
 #ifndef P_LKRG_FTRACE_ENABLE_SYSCTL_H
 #define P_LKRG_FTRACE_ENABLE_SYSCTL_H
 
+#include "../../../exploit_detection/syscalls/p_install.h"
 
-int p_ftrace_enable_sysctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_ftrace_enable_sysctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_ftrace_enable_sysctl_hook(void);
-void p_uninstall_ftrace_enable_sysctl_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(ftrace_enable_sysctl)
 
 #endif
 

--- a/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.h
+++ b/src/modules/database/FTRACE/p_ftrace_enable_sysctl/p_ftrace_enable_sysctl.h
@@ -30,11 +30,6 @@
 #ifndef P_LKRG_FTRACE_ENABLE_SYSCTL_H
 #define P_LKRG_FTRACE_ENABLE_SYSCTL_H
 
-/* per-instance private data */
-struct p_ftrace_enable_sysctl_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_ftrace_enable_sysctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_ftrace_enable_sysctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -68,7 +68,7 @@ static notrace int p_ftrace_modify_all_code_entry(struct kretprobe_instance *p_r
       p_ftrace_tmp_text++;
    }
 
-   p_for_ftrace_rec_iter(p_iter) {
+   for (p_iter = P_SYM(p_ftrace_rec_iter_start)(); p_iter; p_iter = P_SYM(p_ftrace_rec_iter_next)(p_iter)) {
       p_rec = P_SYM(p_ftrace_rec_iter_record)(p_iter);
 
       if (P_SYM(p_core_kernel_text)(p_rec->ip)) {

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -35,7 +35,6 @@ static struct kretprobe p_ftrace_modify_all_code_kretprobe = {
     .kp.symbol_name = "ftrace_modify_all_code",
     .handler = p_ftrace_modify_all_code_ret,
     .entry_handler = p_ftrace_modify_all_code_entry,
-    .data_size = sizeof(struct p_ftrace_modify_all_code_data),
 };
 
 /*

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.h
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.h
@@ -30,16 +30,14 @@
 #ifndef P_LKRG_FTRACE_MODIFY_ALL_CODE_H
 #define P_LKRG_FTRACE_MODIFY_ALL_CODE_H
 
+#include "../../../exploit_detection/syscalls/p_install.h"
+
 #define p_for_ftrace_rec_iter(iter)                    \
    for (iter = P_SYM(p_ftrace_rec_iter_start)();       \
         iter;                                          \
         iter = P_SYM(p_ftrace_rec_iter_next)(iter))
 
-
-int p_ftrace_modify_all_code_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_ftrace_modify_all_code_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_ftrace_modify_all_code_hook(void);
-void p_uninstall_ftrace_modify_all_code_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(ftrace_modify_all_code)
 
 #endif
 

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.h
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.h
@@ -32,11 +32,6 @@
 
 #include "../../../exploit_detection/syscalls/p_install.h"
 
-#define p_for_ftrace_rec_iter(iter)                    \
-   for (iter = P_SYM(p_ftrace_rec_iter_start)();       \
-        iter;                                          \
-        iter = P_SYM(p_ftrace_rec_iter_next)(iter))
-
 GENERATE_INSTALL_FUNC_PROTO(ftrace_modify_all_code)
 
 #endif

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.h
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.h
@@ -30,11 +30,6 @@
 #ifndef P_LKRG_FTRACE_MODIFY_ALL_CODE_H
 #define P_LKRG_FTRACE_MODIFY_ALL_CODE_H
 
-/* per-instance private data */
-struct p_ftrace_modify_all_code_data {
-    ktime_t entry_stamp;
-};
-
 #define p_for_ftrace_rec_iter(iter)                    \
    for (iter = P_SYM(p_ftrace_rec_iter_start)();       \
         iter;                                          \

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -39,7 +39,6 @@ static struct kretprobe p_arch_jump_label_transform_kretprobe = {
 #endif
     .handler = p_arch_jump_label_transform_ret,
     .entry_handler = p_arch_jump_label_transform_entry,
-    .data_size = sizeof(struct p_arch_jump_label_transform_data),
 };
 
 

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.h
@@ -28,11 +28,6 @@
 #ifndef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_H
 #define P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_H
 
-/* per-instance private data */
-struct p_arch_jump_label_transform_data {
-    ktime_t entry_stamp;
-};
-
 extern p_lkrg_counter_lock p_jl_lock;
 
 int p_arch_jump_label_transform_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.h
@@ -28,11 +28,10 @@
 #ifndef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_H
 #define P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_H
 
+#include "../../../exploit_detection/syscalls/p_install.h"
+
 extern p_lkrg_counter_lock p_jl_lock;
 
-int p_arch_jump_label_transform_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_arch_jump_label_transform_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_arch_jump_label_transform_hook(void);
-void p_uninstall_arch_jump_label_transform_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(arch_jump_label_transform)
 
 #endif

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -41,7 +41,6 @@ static struct kretprobe p_arch_jump_label_transform_apply_kretprobe = {
     .kp.symbol_name = "arch_jump_label_transform_apply",
     .handler = p_arch_jump_label_transform_apply_ret,
     .entry_handler = p_arch_jump_label_transform_apply_entry,
-    .data_size = sizeof(struct p_arch_jump_label_transform_apply_data),
 };
 
 

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -89,11 +89,9 @@ typedef struct text_poke_loc p_text_poke_loc;
 
 #define P_TP_VEC_MAX (PAGE_SIZE / sizeof(p_text_poke_loc))
 
+#include "../../../exploit_detection/syscalls/p_install.h"
 
-int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_arch_jump_label_transform_apply_hook(void);
-void p_uninstall_arch_jump_label_transform_apply_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(arch_jump_label_transform_apply)
 
 #endif
 

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -89,11 +89,6 @@ typedef struct text_poke_loc p_text_poke_loc;
 
 #define P_TP_VEC_MAX (PAGE_SIZE / sizeof(p_text_poke_loc))
 
-/* per-instance private data */
-struct p_arch_jump_label_transform_apply_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_arch_jump_label_transform_apply_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
@@ -29,7 +29,6 @@ static struct kretprobe p_arch_static_call_transform_kretprobe = {
     .kp.symbol_name = "arch_static_call_transform",
     .handler = p_arch_static_call_transform_ret,
     .entry_handler = p_arch_static_call_transform_entry,
-    .data_size = sizeof(struct p_arch_static_call_transform_data),
 };
 
 static unsigned long p_tracepoint_tmp_text;

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
@@ -20,16 +20,9 @@
  */
 
 #include "../../../../p_lkrg_main.h"
+#include "../../../exploit_detection/syscalls/p_install.h"
 
 #if defined(P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H)
-
-static char p_arch_static_call_transform_kretprobe_state = 0;
-
-static struct kretprobe p_arch_static_call_transform_kretprobe = {
-    .kp.symbol_name = "arch_static_call_transform",
-    .handler = p_arch_static_call_transform_ret,
-    .entry_handler = p_arch_static_call_transform_entry,
-};
 
 static unsigned long p_tracepoint_tmp_text;
 static struct module *p_module1;
@@ -39,7 +32,7 @@ static unsigned int p_module2_idx;
 
 p_lkrg_counter_lock p_static_call_spinlock;
 
-notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    unsigned long p_site = p_regs_get_arg1(p_regs);
    unsigned long p_tramp = p_regs_get_arg2(p_regs);
@@ -135,7 +128,7 @@ notrace int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, 
 }
 
 
-notrace int p_arch_static_call_transform_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static notrace int p_arch_static_call_transform_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    unsigned int p_tmp;
    unsigned char p_flag = 0;
@@ -260,42 +253,15 @@ notrace int p_arch_static_call_transform_ret(struct kretprobe_instance *ri, stru
 }
 
 
-int p_install_arch_static_call_transform_hook(void) {
+static struct lkrg_probe p_arch_static_call_transform_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "arch_static_call_transform",
+    .handler = p_arch_static_call_transform_ret,
+    .entry_handler = p_arch_static_call_transform_entry,
+  }
+};
 
-   int p_tmp;
-
-   p_lkrg_counter_lock_init(&p_static_call_spinlock);
-
-   p_arch_static_call_transform_kretprobe.maxactive = p_get_kprobe_maxactive();
-   if ( (p_tmp = register_kretprobe(&p_arch_static_call_transform_kretprobe)) != 0) {
-      p_print_log(P_LOG_FATAL, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
-                  p_arch_static_call_transform_kretprobe.kp.symbol_name,
-                  p_tmp);
-      return P_LKRG_GENERAL_ERROR;
-   }
-   p_print_log(P_LOG_WATCH, "Planted [kretprobe] <%s> at: 0x%lx",
-               p_arch_static_call_transform_kretprobe.kp.symbol_name,
-               (unsigned long)p_arch_static_call_transform_kretprobe.kp.addr);
-   p_arch_static_call_transform_kretprobe_state = 1;
-
-   return P_LKRG_SUCCESS;
-}
-
-
-void p_uninstall_arch_static_call_transform_hook(void) {
-
-   if (!p_arch_static_call_transform_kretprobe_state) {
-      p_print_log(P_LOG_WATCH, "[kretprobe] <%s> at 0x%lx is NOT installed",
-                  p_arch_static_call_transform_kretprobe.kp.symbol_name,
-                  (unsigned long)p_arch_static_call_transform_kretprobe.kp.addr);
-   } else {
-      unregister_kretprobe(&p_arch_static_call_transform_kretprobe);
-      p_print_log(P_LOG_WATCH, "Removing [kretprobe] <%s> at 0x%lx nmissed[%d]",
-                  p_arch_static_call_transform_kretprobe.kp.symbol_name,
-                  (unsigned long)p_arch_static_call_transform_kretprobe.kp.addr,
-                  p_arch_static_call_transform_kretprobe.nmissed);
-      p_arch_static_call_transform_kretprobe_state = 0;
-   }
-}
+GENERATE_INSTALL_FUNC(arch_static_call_transform)
 
 #endif

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.h
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.h
@@ -24,11 +24,6 @@
 #ifndef P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H
 #define P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H
 
-/* per-instance private data */
-struct p_arch_static_call_transform_data {
-    ktime_t entry_stamp;
-};
-
 extern p_lkrg_counter_lock p_static_call_spinlock;
 
 int p_arch_static_call_transform_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.h
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.h
@@ -24,12 +24,11 @@
 #ifndef P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H
 #define P_LKRG_CI_ARCH_STATIC_CALL_TRANSFORM_H
 
+#include "../../../exploit_detection/syscalls/p_install.h"
+
 extern p_lkrg_counter_lock p_static_call_spinlock;
 
-int p_arch_static_call_transform_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_arch_static_call_transform_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_arch_static_call_transform_hook(void);
-void p_uninstall_arch_static_call_transform_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(arch_static_call_transform)
 
 #endif
 

--- a/src/modules/database/arch/p_arch_metadata.c
+++ b/src/modules/database/arch/p_arch_metadata.c
@@ -44,7 +44,7 @@ int p_register_arch_metadata(void) {
 
 #ifdef P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
 
-   if (p_install_switch_idt_hook()) {
+   if (p_install_switch_idt_hook(0)) {
       p_print_log(P_LOG_ISSUE,
              "Can't hook 'switch_idt'. "
              "It's OK, but tracepoints might not be supported correctly "
@@ -58,18 +58,30 @@ int p_register_arch_metadata(void) {
 #endif
 
    /*
+    * This lock is used in our hooks of arch_jump_label_transform() and
+    * arch_jump_label_transform_apply().
+    */
+   p_lkrg_counter_lock_init(&p_jl_lock);
+
+   /*
     * This is not an arch specific hook, but it's a good place to register it
     */
-   if (p_install_arch_jump_label_transform_hook()) {
+   if (p_install_arch_jump_label_transform_hook(0)) {
       p_print_log(P_LOG_FATAL, "Can't hook 'arch_jump_label_transform'");
       return P_LKRG_GENERAL_ERROR;
    }
 
 #ifdef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
    /*
+    * These symbols are used in our hook of arch_jump_label_transform_apply().
+    */
+   P_SYM_INIT(tp_vec)
+   P_SYM_INIT(tp_vec_nr)
+
+   /*
     * This is not an arch specific hook, but it's a good place to register it
     */
-   if (p_install_arch_jump_label_transform_apply_hook()) {
+   if (p_install_arch_jump_label_transform_apply_hook(0)) {
       p_print_log(P_LOG_FATAL, "Can't hook 'arch_jump_label_transform_apply'");
       return P_LKRG_GENERAL_ERROR;
    }
@@ -77,23 +89,36 @@ int p_register_arch_metadata(void) {
 
 #if defined(CONFIG_DYNAMIC_FTRACE)
    /*
+    * These symbols are used in our hook of ftrace_modify_all_code().
+    */
+   P_SYM_INIT(ftrace_lock)
+   P_SYM_INIT(ftrace_rec_iter_start)
+   P_SYM_INIT(ftrace_rec_iter_next)
+   P_SYM_INIT(ftrace_rec_iter_record)
+
+   /*
     * Same for FTRACE
     */
-   if (p_install_ftrace_modify_all_code_hook()) {
+   if (p_install_ftrace_modify_all_code_hook(0)) {
       p_print_log(P_LOG_FATAL, "Can't hook 'ftrace_modify_all_code'");
       return P_LKRG_GENERAL_ERROR;
    }
 #endif
 
 #if defined(CONFIG_FUNCTION_TRACER)
-   if (p_install_ftrace_enable_sysctl_hook()) {
+   if (p_install_ftrace_enable_sysctl_hook(0)) {
       p_print_log(P_LOG_FATAL, "Can't hook 'ftrace_enable_sysctl'");
       return P_LKRG_GENERAL_ERROR;
    }
 #endif
 
 #if defined(CONFIG_HAVE_STATIC_CALL)
-   if (p_install_arch_static_call_transform_hook()) {
+   /*
+    * This lock is used in our hook of arch_static_call_transform().
+    */
+   p_lkrg_counter_lock_init(&p_static_call_spinlock);
+
+   if (p_install_arch_static_call_transform_hook(0)) {
       p_print_log(P_LOG_FATAL, "Can't hook 'arch_jump_label_transform'");
       return P_LKRG_GENERAL_ERROR;
    }

--- a/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
+++ b/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.c
@@ -31,7 +31,6 @@ static struct kretprobe p_switch_idt_kretprobe = {
     .kp.symbol_name = "switch_idt",
     .handler = p_switch_idt_ret,
     .entry_handler = p_switch_idt_entry,
-    .data_size = sizeof(struct p_switch_idt_data),
 };
 
 

--- a/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.h
+++ b/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.h
@@ -28,11 +28,6 @@
 #ifndef P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
 #define P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
 
-/* per-instance private data */
-struct p_switch_idt_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_switch_idt_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_switch_idt_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.h
+++ b/src/modules/database/arch/x86/p_switch_idt/p_switch_idt.h
@@ -28,11 +28,9 @@
 #ifndef P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
 #define P_LKRG_RUNTIME_CODE_INTEGRITY_SWITCH_IDT_H
 
+#include "../../../../exploit_detection/syscalls/p_install.h"
 
-int p_switch_idt_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_switch_idt_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_switch_idt_hook(void);
-void p_uninstall_switch_idt_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(switch_idt)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
@@ -24,17 +24,7 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-static struct lkrg_probe p_x32_sys_keyctl_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_X32_SYSCALL_NAME(keyctl),
-    .handler = p_x32_sys_keyctl_ret,
-    .entry_handler = p_x32_sys_keyctl_entry,
-  }
-};
-
-
-int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -51,8 +41,7 @@ int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    return 0;
 }
 
-
-int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -76,6 +65,14 @@ int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    return 0;
 }
 
+static struct lkrg_probe p_x32_sys_keyctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_X32_SYSCALL_NAME(keyctl),
+    .handler = p_x32_sys_keyctl_ret,
+    .entry_handler = p_x32_sys_keyctl_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(x32_sys_keyctl)
 

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
@@ -24,13 +24,13 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-
-char p_x32_sys_keyctl_kretprobe_state = 0;
-
-static struct kretprobe p_x32_sys_keyctl_kretprobe = {
+static struct lkrg_probe p_x32_sys_keyctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_X32_SYSCALL_NAME(keyctl),
     .handler = p_x32_sys_keyctl_ret,
     .entry_handler = p_x32_sys_keyctl_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.c
@@ -31,7 +31,6 @@ static struct kretprobe p_x32_sys_keyctl_kretprobe = {
     .kp.symbol_name = P_GET_X32_SYSCALL_NAME(keyctl),
     .handler = p_x32_sys_keyctl_ret,
     .entry_handler = p_x32_sys_keyctl_entry,
-    .data_size = sizeof(struct p_x32_sys_keyctl_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.h
@@ -25,11 +25,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_X32_SYS_KEYCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_X32_SYS_KEYCTL_H
 
-/* per-instance private data */
-struct p_x32_sys_keyctl_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.h
@@ -28,8 +28,7 @@
 
 int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_x32_sys_keyctl_hook(int p_isra);
-void p_uninstall_x32_sys_keyctl_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(x32_sys_keyctl)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/__x32/p_x32_sys_keyctl/p_x32_sys_keyctl.h
@@ -25,9 +25,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_X32_SYS_KEYCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_X32_SYS_KEYCTL_H
 
-
-int p_x32_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_x32_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(x32_sys_keyctl)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_cap_task_prctl_kretprobe_state = 0;
-
-static struct kretprobe p_cap_task_prctl_kretprobe = {
+static struct lkrg_probe p_cap_task_prctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "cap_task_prctl",
     .handler = p_cap_task_prctl_ret,
     .entry_handler = p_cap_task_prctl_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
@@ -27,7 +27,6 @@ static struct kretprobe p_cap_task_prctl_kretprobe = {
     .kp.symbol_name = "cap_task_prctl",
     .handler = p_cap_task_prctl_ret,
     .entry_handler = p_cap_task_prctl_entry,
-    .data_size = sizeof(struct p_cap_task_prctl_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.c
@@ -20,17 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_cap_task_prctl_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "cap_task_prctl",
-    .handler = p_cap_task_prctl_ret,
-    .entry_handler = p_cap_task_prctl_entry,
-  }
-};
-
-
-int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_re
    return 0;
 }
 
-
-int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    long p_ret = (long)p_regs_get_ret(p_regs);
@@ -73,5 +62,13 @@ int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) 
    return 0;
 }
 
+static struct lkrg_probe p_cap_task_prctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "cap_task_prctl",
+    .handler = p_cap_task_prctl_ret,
+    .entry_handler = p_cap_task_prctl_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(cap_task_prctl)

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.h
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.h
@@ -24,7 +24,6 @@
 
 int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_cap_task_prctl_hook(int p_isra);
-void p_uninstall_cap_task_prctl_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(cap_task_prctl)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.h
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CAP_TASK_PRCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_CAP_TASK_PRCTL_H
 
-/* per-instance private data */
-struct p_cap_task_prctl_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.h
+++ b/src/modules/exploit_detection/syscalls/caps/p_cap_task_prctl/p_cap_task_prctl.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CAP_TASK_PRCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_CAP_TASK_PRCTL_H
 
-
-int p_cap_task_prctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_cap_task_prctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(cap_task_prctl)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
@@ -20,17 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_capset_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SYSCALL_NAME(capset),
-    .handler = p_sys_capset_ret,
-    .entry_handler = p_sys_capset_entry,
-  }
-};
-
-
-int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    return 0;
 }
 
-
-int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_capset_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SYSCALL_NAME(capset),
+    .handler = p_sys_capset_ret,
+    .entry_handler = p_sys_capset_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_capset)

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_capset_kretprobe = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(capset),
     .handler = p_sys_capset_ret,
     .entry_handler = p_sys_capset_entry,
-    .data_size = sizeof(struct p_sys_capset_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_sys_capset_kretprobe_state = 0;
-
-static struct kretprobe p_sys_capset_kretprobe = {
+static struct lkrg_probe p_sys_capset_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(capset),
     .handler = p_sys_capset_ret,
     .entry_handler = p_sys_capset_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.h
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_CAPSET_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_CAPSET_H
 
-/* per-instance private data */
-struct p_sys_capset_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.h
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_CAPSET_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_CAPSET_H
 
-
-int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_capset)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.h
+++ b/src/modules/exploit_detection/syscalls/caps/p_sys_capset/p_sys_capset.h
@@ -24,7 +24,6 @@
 
 int p_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_capset_hook(int p_isra);
-void p_uninstall_sys_capset_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_capset)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
@@ -27,13 +27,13 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-
-char p_compat_sys_add_key_kretprobe_state = 0;
-
-static struct kretprobe p_compat_sys_add_key_kretprobe = {
+static struct lkrg_probe p_compat_sys_add_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(add_key),
     .handler = p_compat_sys_add_key_ret,
     .entry_handler = p_compat_sys_add_key_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
@@ -34,7 +34,6 @@ static struct kretprobe p_compat_sys_add_key_kretprobe = {
     .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(add_key),
     .handler = p_compat_sys_add_key_ret,
     .entry_handler = p_compat_sys_add_key_entry,
-    .data_size = sizeof(struct p_compat_sys_add_key_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.c
@@ -27,17 +27,7 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-static struct lkrg_probe p_compat_sys_add_key_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(add_key),
-    .handler = p_compat_sys_add_key_ret,
-    .entry_handler = p_compat_sys_add_key_entry,
-  }
-};
-
-
-int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -54,8 +44,7 @@ int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *
    return 0;
 }
 
-
-int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -79,6 +68,14 @@ int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
    return 0;
 }
 
+static struct lkrg_probe p_compat_sys_add_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(add_key),
+    .handler = p_compat_sys_add_key_ret,
+    .entry_handler = p_compat_sys_add_key_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(compat_sys_add_key)
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.h
@@ -26,11 +26,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_ADD_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_ADD_KEY_H
 
-/* per-instance private data */
-struct p_compat_sys_add_key_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.h
@@ -26,9 +26,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_ADD_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_ADD_KEY_H
 
-
-int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(compat_sys_add_key)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_add_key/p_compat_sys_add_key.h
@@ -29,8 +29,7 @@
 
 int p_compat_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_compat_sys_add_key_hook(int p_isra);
-void p_uninstall_compat_sys_add_key_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(compat_sys_add_key)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
@@ -27,13 +27,13 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-
-char p_compat_sys_capset_kretprobe_state = 0;
-
-static struct kretprobe p_compat_sys_capset_kretprobe = {
+static struct lkrg_probe p_compat_sys_capset_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(capset),
     .handler = p_compat_sys_capset_ret,
     .entry_handler = p_compat_sys_capset_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
@@ -27,17 +27,7 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-static struct lkrg_probe p_compat_sys_capset_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(capset),
-    .handler = p_compat_sys_capset_ret,
-    .entry_handler = p_compat_sys_capset_entry,
-  }
-};
-
-
-int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -54,8 +44,7 @@ int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    return 0;
 }
 
-
-int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -79,6 +68,14 @@ int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    return 0;
 }
 
+static struct lkrg_probe p_compat_sys_capset_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(capset),
+    .handler = p_compat_sys_capset_ret,
+    .entry_handler = p_compat_sys_capset_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(compat_sys_capset)
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.c
@@ -34,7 +34,6 @@ static struct kretprobe p_compat_sys_capset_kretprobe = {
     .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(capset),
     .handler = p_compat_sys_capset_ret,
     .entry_handler = p_compat_sys_capset_entry,
-    .data_size = sizeof(struct p_compat_sys_capset_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.h
@@ -26,11 +26,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_CAPSET_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_CAPSET_H
 
-/* per-instance private data */
-struct p_compat_sys_capset_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.h
@@ -26,9 +26,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_CAPSET_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_CAPSET_H
 
-
-int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(compat_sys_capset)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_capset/p_compat_sys_capset.h
@@ -29,8 +29,7 @@
 
 int p_compat_sys_capset_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_capset_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_compat_sys_capset_hook(int p_isra);
-void p_uninstall_compat_sys_capset_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(compat_sys_capset)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
@@ -22,17 +22,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_compat_sys_keyctl_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_COMPAT_SYSCALL_NAME(keyctl),
-    .handler = p_compat_sys_keyctl_ret,
-    .entry_handler = p_compat_sys_keyctl_entry,
-  }
-};
-
-
-int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -49,8 +39,7 @@ int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    return 0;
 }
 
-
-int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -74,6 +63,14 @@ int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_reg
    return 0;
 }
 
+static struct lkrg_probe p_compat_sys_keyctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_COMPAT_SYSCALL_NAME(keyctl),
+    .handler = p_compat_sys_keyctl_ret,
+    .entry_handler = p_compat_sys_keyctl_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(compat_sys_keyctl)
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
@@ -22,13 +22,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_compat_sys_keyctl_kretprobe_state = 0;
-
-static struct kretprobe p_compat_sys_keyctl_kretprobe = {
+static struct lkrg_probe p_compat_sys_keyctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_COMPAT_SYSCALL_NAME(keyctl),
     .handler = p_compat_sys_keyctl_ret,
     .entry_handler = p_compat_sys_keyctl_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.c
@@ -29,7 +29,6 @@ static struct kretprobe p_compat_sys_keyctl_kretprobe = {
     .kp.symbol_name = P_GET_COMPAT_SYSCALL_NAME(keyctl),
     .handler = p_compat_sys_keyctl_ret,
     .entry_handler = p_compat_sys_keyctl_entry,
-    .data_size = sizeof(struct p_compat_sys_keyctl_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.h
@@ -23,9 +23,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_KEYCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_KEYCTL_H
 
-
-int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(compat_sys_keyctl)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.h
@@ -26,8 +26,7 @@
 
 int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_compat_sys_keyctl_hook(int p_isra);
-void p_uninstall_compat_sys_keyctl_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(compat_sys_keyctl)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_keyctl/p_compat_sys_keyctl.h
@@ -23,11 +23,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_KEYCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_KEYCTL_H
 
-/* per-instance private data */
-struct p_compat_sys_keyctl_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_compat_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
@@ -34,7 +34,6 @@ static struct kretprobe p_compat_sys_request_key_kretprobe = {
     .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(request_key),
     .handler = p_compat_sys_request_key_ret,
     .entry_handler = p_compat_sys_request_key_entry,
-    .data_size = sizeof(struct p_compat_sys_request_key_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
@@ -27,17 +27,7 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-static struct lkrg_probe p_compat_sys_request_key_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(request_key),
-    .handler = p_compat_sys_request_key_ret,
-    .entry_handler = p_compat_sys_request_key_entry,
-  }
-};
-
-
-int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -54,8 +44,7 @@ int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_re
    return 0;
 }
 
-
-int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -79,6 +68,14 @@ int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *
    return 0;
 }
 
+static struct lkrg_probe p_compat_sys_request_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(request_key),
+    .handler = p_compat_sys_request_key_ret,
+    .entry_handler = p_compat_sys_request_key_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(compat_sys_request_key)
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.c
@@ -27,13 +27,13 @@
 
 #ifdef P_SYSCALL_LAYOUT_4_17
 
-
-char p_compat_sys_request_key_kretprobe_state = 0;
-
-static struct kretprobe p_compat_sys_request_key_kretprobe = {
+static struct lkrg_probe p_compat_sys_request_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_NEW_COMPAT_SYSCALL_NAME(request_key),
     .handler = p_compat_sys_request_key_ret,
     .entry_handler = p_compat_sys_request_key_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.h
@@ -26,9 +26,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_REQUEST_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_REQUEST_KEY_H
 
-
-int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(compat_sys_request_key)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.h
@@ -26,11 +26,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_REQUEST_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_COMPAT_SYS_REQUEST_KEY_H
 
-/* per-instance private data */
-struct p_compat_sys_request_key_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.h
+++ b/src/modules/exploit_detection/syscalls/compat/p_compat_sys_request_key/p_compat_sys_request_key.h
@@ -29,8 +29,7 @@
 
 int p_compat_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_compat_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_compat_sys_request_key_hook(int p_isra);
-void p_uninstall_compat_sys_request_key_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(compat_sys_request_key)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -26,40 +26,6 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-notrace struct inode *p_get_inode_from_task(struct task_struct *p_arg) {
-
-   struct mm_struct *p_mm;
-   struct inode *p_inode = NULL;
-
-   if (!p_arg) {
-      return NULL;
-   }
-
-   /*
-    * This function is called from the context of newly created
-    * Process which is intercepted by our *probes. This means
-    * Process did not take control yet. Before we finish our work
-    * Nothing bad should happen in context of parsing mm_struct.
-    * For this specific operation (reading pointer to exe_file)
-    * It is safe to not use read lock. Process can't die before it
-    * is not even taken control.
-    * Additionally, we are under IRQ disabled context and it is
-    * Not safe to take any mutex/semaphore since we can be forced
-    * to sleep.
-    * Current implementation works well!
-    */
-//   down_read(&p_arg->mm->mmap_sem);
-
-   p_mm = p_arg->mm;
-   if (p_mm->exe_file) {
-      p_inode = p_mm->exe_file->f_inode;
-   }
-
-//   up_read(&p_arg->mm->mmap_sem);
-
-   return p_inode;
-}
-
 static LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
 //   struct inode *p_inode;

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -27,12 +27,13 @@
 #include "../../../../../p_lkrg_main.h"
 
 
-char p_security_bprm_committed_creds_kretprobe_state = 0;
-
-static struct kretprobe p_security_bprm_committed_creds_kretprobe = {
+static struct lkrg_probe p_security_bprm_committed_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "security_bprm_committed_creds",
     .handler = p_security_bprm_committed_creds_ret,
     .entry_handler = NULL,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -33,7 +33,6 @@ static struct kretprobe p_security_bprm_committed_creds_kretprobe = {
     .kp.symbol_name = "security_bprm_committed_creds",
     .handler = p_security_bprm_committed_creds_ret,
     .entry_handler = NULL,
-    .data_size = sizeof(struct p_security_bprm_committed_creds_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -26,17 +26,6 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-static struct lkrg_probe p_security_bprm_committed_creds_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "security_bprm_committed_creds",
-    .handler = p_security_bprm_committed_creds_ret,
-    .entry_handler = NULL,
-  }
-};
-
-
 notrace struct inode *p_get_inode_from_task(struct task_struct *p_arg) {
 
    struct mm_struct *p_mm;
@@ -71,7 +60,7 @@ notrace struct inode *p_get_inode_from_task(struct task_struct *p_arg) {
    return p_inode;
 }
 
-LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
 //   struct inode *p_inode;
    struct p_ed_process *p_tmp;
@@ -89,5 +78,14 @@ LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe_instan
 
    return 0;
 }
+
+static struct lkrg_probe p_security_bprm_committed_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "security_bprm_committed_creds",
+    .handler = p_security_bprm_committed_creds_ret,
+    .entry_handler = NULL,
+  }
+};
 
 GENERATE_INSTALL_FUNC(security_bprm_committed_creds)

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
@@ -30,11 +30,6 @@
 #define P_MAX_PATH PATH_MAX + 0x20 /* For weirdos used by d_path */
 
 
-/* per-instance private data */
-struct p_security_bprm_committed_creds_data {
-    ktime_t entry_stamp;
-};
-
 
 struct inode *p_get_inode_from_task(struct task_struct *p_arg);
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
@@ -27,10 +27,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTED_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTED_CREDS_H
 
-#define P_MAX_PATH PATH_MAX + 0x20 /* For weirdos used by d_path */
-
-struct inode *p_get_inode_from_task(struct task_struct *p_arg);
-
 GENERATE_INSTALL_FUNC_PROTO(security_bprm_committed_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
@@ -29,11 +29,8 @@
 
 #define P_MAX_PATH PATH_MAX + 0x20 /* For weirdos used by d_path */
 
-
-
 struct inode *p_get_inode_from_task(struct task_struct *p_arg);
 
-int p_security_bprm_committed_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(security_bprm_committed_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.h
@@ -34,7 +34,6 @@
 struct inode *p_get_inode_from_task(struct task_struct *p_arg);
 
 int p_security_bprm_committed_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_security_bprm_committed_creds_hook(int p_isra);
-void p_uninstall_security_bprm_committed_creds_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(security_bprm_committed_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -27,14 +27,15 @@
 #include "../../../../../p_lkrg_main.h"
 
 
-char p_security_bprm_committing_creds_kretprobe_state = 0;
-
 LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) { return 0; }
 
-static struct kretprobe p_security_bprm_committing_creds_kretprobe = {
+static struct lkrg_probe p_security_bprm_committing_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "security_bprm_committing_creds",
     .handler = p_security_bprm_committing_creds_ret,
     .entry_handler = p_security_bprm_committing_creds_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -26,17 +26,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-static struct lkrg_probe p_security_bprm_committing_creds_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "security_bprm_committing_creds",
-    .kp.pre_handler = p_security_bprm_committing_creds_entry,
-  }
-};
-
-
-LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -53,5 +43,13 @@ LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_entry(struct kprobe *p_ri,
 
    return 0;
 }
+
+static struct lkrg_probe p_security_bprm_committing_creds_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "security_bprm_committing_creds",
+    .kp.pre_handler = p_security_bprm_committing_creds_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(security_bprm_committing_creds)

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -27,19 +27,16 @@
 #include "../../../../../p_lkrg_main.h"
 
 
-LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) { return 0; }
-
 static struct lkrg_probe p_security_bprm_committing_creds_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "security_bprm_committing_creds",
-    .handler = p_security_bprm_committing_creds_ret,
-    .entry_handler = p_security_bprm_committing_creds_entry,
+    .kp.pre_handler = p_security_bprm_committing_creds_entry,
   }
 };
 
 
-LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+LKRG_DEBUG_TRACE int p_security_bprm_committing_creds_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.c
@@ -35,7 +35,6 @@ static struct kretprobe p_security_bprm_committing_creds_kretprobe = {
     .kp.symbol_name = "security_bprm_committing_creds",
     .handler = p_security_bprm_committing_creds_ret,
     .entry_handler = p_security_bprm_committing_creds_entry,
-    .data_size = sizeof(struct p_security_bprm_committing_creds_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
@@ -27,11 +27,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 
-/* per-instance private data */
-struct p_security_bprm_committing_creds_data {
-    ktime_t entry_stamp;
-};
-
 int p_security_bprm_committing_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_security_bprm_committing_creds_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
@@ -27,7 +27,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 
-int p_security_bprm_committing_creds_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(security_bprm_committing_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
@@ -27,8 +27,7 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 
-int p_security_bprm_committing_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_security_bprm_committing_creds_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_security_bprm_committing_creds_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_security_bprm_committing_creds_hook(int p_isra);
 void p_uninstall_security_bprm_committing_creds_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committing_creds/p_security_bprm_committing_creds.h
@@ -28,7 +28,6 @@
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_BPRM_COMMITTING_CREDS_H
 
 int p_security_bprm_committing_creds_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_security_bprm_committing_creds_hook(int p_isra);
-void p_uninstall_security_bprm_committing_creds_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(security_bprm_committing_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_key_change_session_keyring_kretprobe_state = 0;
-
-static struct kretprobe p_key_change_session_keyring_kretprobe = {
+static struct lkrg_probe p_key_change_session_keyring_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "key_change_session_keyring",
     .handler = p_key_change_session_keyring_ret,
     .entry_handler = p_key_change_session_keyring_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
@@ -20,17 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_key_change_session_keyring_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "key_change_session_keyring",
-    .handler = p_key_change_session_keyring_ret,
-    .entry_handler = p_key_change_session_keyring_entry,
-  }
-};
-
-
-int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    if ((p_tmp = ed_task_lock_current())) {
@@ -45,8 +35,7 @@ int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct p
    return 0;
 }
 
-
-int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -69,5 +58,13 @@ int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_re
    return 0;
 }
 
+static struct lkrg_probe p_key_change_session_keyring_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "key_change_session_keyring",
+    .handler = p_key_change_session_keyring_ret,
+    .entry_handler = p_key_change_session_keyring_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(key_change_session_keyring)

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.c
@@ -27,7 +27,6 @@ static struct kretprobe p_key_change_session_keyring_kretprobe = {
     .kp.symbol_name = "key_change_session_keyring",
     .handler = p_key_change_session_keyring_ret,
     .entry_handler = p_key_change_session_keyring_entry,
-    .data_size = sizeof(struct p_key_change_session_keyring_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.h
@@ -24,7 +24,6 @@
 
 int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_key_change_session_keyring_hook(int p_isra);
-void p_uninstall_key_change_session_keyring_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(key_change_session_keyring)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_KEY_CHANGE_SESSION_KEYRING_H
 #define P_LKRG_EXPLOIT_DETECTION_KEY_CHANGE_SESSION_KEYRING_H
 
-
-int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(key_change_session_keyring)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_key_change_session_keyring/p_key_change_session_keyring.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_KEY_CHANGE_SESSION_KEYRING_H
 #define P_LKRG_EXPLOIT_DETECTION_KEY_CHANGE_SESSION_KEYRING_H
 
-/* per-instance private data */
-struct p_key_change_session_keyring_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_key_change_session_keyring_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_key_change_session_keyring_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_add_key_kretprobe = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(add_key),
     .handler = p_sys_add_key_ret,
     .entry_handler = p_sys_add_key_entry,
-    .data_size = sizeof(struct p_sys_add_key_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_sys_add_key_kretprobe_state = 0;
-
-static struct kretprobe p_sys_add_key_kretprobe = {
+static struct lkrg_probe p_sys_add_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(add_key),
     .handler = p_sys_add_key_ret,
     .entry_handler = p_sys_add_key_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.c
@@ -20,17 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_add_key_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SYSCALL_NAME(add_key),
-    .handler = p_sys_add_key_ret,
-    .entry_handler = p_sys_add_key_entry,
-  }
-};
-
-
-int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs)
    return 0;
 }
 
-
-int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_add_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SYSCALL_NAME(add_key),
+    .handler = p_sys_add_key_ret,
+    .entry_handler = p_sys_add_key_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_add_key)

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_ADD_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_ADD_KEY_H
 
-
-int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_add_key)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_ADD_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_ADD_KEY_H
 
-/* per-instance private data */
-struct p_sys_add_key_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_add_key/p_sys_add_key.h
@@ -24,7 +24,6 @@
 
 int p_sys_add_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_add_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_add_key_hook(int p_isra);
-void p_uninstall_sys_add_key_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_add_key)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_keyctl_kretprobe = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(keyctl),
     .handler = p_sys_keyctl_ret,
     .entry_handler = p_sys_keyctl_entry,
-    .data_size = sizeof(struct p_sys_keyctl_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
@@ -20,17 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_keyctl_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SYSCALL_NAME(keyctl),
-    .handler = p_sys_keyctl_ret,
-    .entry_handler = p_sys_keyctl_entry,
-  }
-};
-
-
-int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    return 0;
 }
 
-
-int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_keyctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SYSCALL_NAME(keyctl),
+    .handler = p_sys_keyctl_ret,
+    .entry_handler = p_sys_keyctl_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_keyctl)

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_sys_keyctl_kretprobe_state = 0;
-
-static struct kretprobe p_sys_keyctl_kretprobe = {
+static struct lkrg_probe p_sys_keyctl_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(keyctl),
     .handler = p_sys_keyctl_ret,
     .entry_handler = p_sys_keyctl_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_KEYCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_KEYCTL_H
 
-
-int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_keyctl)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_KEYCTL_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_KEYCTL_H
 
-/* per-instance private data */
-struct p_sys_keyctl_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_keyctl/p_sys_keyctl.h
@@ -24,7 +24,6 @@
 
 int p_sys_keyctl_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_keyctl_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_keyctl_hook(int p_isra);
-void p_uninstall_sys_keyctl_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_keyctl)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_sys_request_key_kretprobe_state = 0;
-
-static struct kretprobe p_sys_request_key_kretprobe = {
+static struct lkrg_probe p_sys_request_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(request_key),
     .handler = p_sys_request_key_ret,
     .entry_handler = p_sys_request_key_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_request_key_kretprobe = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(request_key),
     .handler = p_sys_request_key_ret,
     .entry_handler = p_sys_request_key_entry,
-    .data_size = sizeof(struct p_sys_request_key_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.c
@@ -20,17 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_request_key_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SYSCALL_NAME(request_key),
-    .handler = p_sys_request_key_ret,
-    .entry_handler = p_sys_request_key_entry,
-  }
-};
-
-
-int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_r
    return 0;
 }
 
-
-int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs)
    return 0;
 }
 
+static struct lkrg_probe p_sys_request_key_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SYSCALL_NAME(request_key),
+    .handler = p_sys_request_key_ret,
+    .entry_handler = p_sys_request_key_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_request_key)

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.h
@@ -24,7 +24,6 @@
 
 int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_request_key_hook(int p_isra);
-void p_uninstall_sys_request_key_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_request_key)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_REQUEST_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_REQUEST_KEY_H
 
-/* per-instance private data */
-struct p_sys_request_key_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.h
+++ b/src/modules/exploit_detection/syscalls/keyring/p_sys_request_key/p_sys_request_key.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_REQUEST_KEY_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_REQUEST_KEY_H
 
-
-int p_sys_request_key_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_request_key_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_request_key)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
@@ -27,32 +27,12 @@
 
 #if P_OVL_OVERRIDE_SYNC_MODE
 
-struct lkrg_probe p_ovl_override_sync_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC,
-    .handler = p_ovl_override_sync_ret,
-    .entry_handler = p_ovl_override_sync_entry,
-  }
-};
-
-
-void p_reinit_ovl_override_sync_kretprobe(void) {
-
-   memset(&p_ovl_override_sync_probe.krp, 0, sizeof(p_ovl_override_sync_probe.krp));
-   p_ovl_override_sync_probe.krp.kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC;
-   p_ovl_override_sync_probe.krp.handler = p_ovl_override_sync_ret;
-   p_ovl_override_sync_probe.krp.entry_handler = p_ovl_override_sync_entry;
-   p_ovl_override_sync_probe.krp.maxactive = p_get_kprobe_maxactive();
-}
-
-int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    return 0;
 }
 
-
-notrace int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static notrace int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -75,6 +55,24 @@ notrace int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_reg
    return 0;
 }
 
+void p_reinit_ovl_override_sync_kretprobe(void) {
+
+   memset(&p_ovl_override_sync_probe.krp, 0, sizeof(p_ovl_override_sync_probe.krp));
+   p_ovl_override_sync_probe.krp.kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC;
+   p_ovl_override_sync_probe.krp.handler = p_ovl_override_sync_ret;
+   p_ovl_override_sync_probe.krp.entry_handler = p_ovl_override_sync_entry;
+   p_ovl_override_sync_probe.krp.maxactive = p_get_kprobe_maxactive();
+}
+
+struct lkrg_probe p_ovl_override_sync_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC,
+    .handler = p_ovl_override_sync_ret,
+    .entry_handler = p_ovl_override_sync_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(ovl_override_sync)
+
 #endif

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
@@ -33,7 +33,6 @@ static struct kretprobe p_ovl_override_sync_kretprobe = {
     .kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC,
     .handler = p_ovl_override_sync_ret,
     .entry_handler = p_ovl_override_sync_entry,
-    .data_size = sizeof(struct p_ovl_override_sync_data),
 };
 
 
@@ -43,7 +42,6 @@ void p_reinit_ovl_override_sync_kretprobe(void) {
    p_ovl_override_sync_kretprobe.kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC;
    p_ovl_override_sync_kretprobe.handler = p_ovl_override_sync_ret;
    p_ovl_override_sync_kretprobe.entry_handler = p_ovl_override_sync_entry;
-   p_ovl_override_sync_kretprobe.data_size = sizeof(struct p_ovl_override_sync_data);
    p_ovl_override_sync_kretprobe.maxactive = p_get_kprobe_maxactive();
 }
 

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.c
@@ -27,22 +27,23 @@
 
 #if P_OVL_OVERRIDE_SYNC_MODE
 
-char p_ovl_override_sync_kretprobe_state = 0;
-
-static struct kretprobe p_ovl_override_sync_kretprobe = {
+struct lkrg_probe p_ovl_override_sync_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC,
     .handler = p_ovl_override_sync_ret,
     .entry_handler = p_ovl_override_sync_entry,
+  }
 };
 
 
 void p_reinit_ovl_override_sync_kretprobe(void) {
 
-   memset(&p_ovl_override_sync_kretprobe,0x0,sizeof(struct kretprobe));
-   p_ovl_override_sync_kretprobe.kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC;
-   p_ovl_override_sync_kretprobe.handler = p_ovl_override_sync_ret;
-   p_ovl_override_sync_kretprobe.entry_handler = p_ovl_override_sync_entry;
-   p_ovl_override_sync_kretprobe.maxactive = p_get_kprobe_maxactive();
+   memset(&p_ovl_override_sync_probe.krp, 0, sizeof(p_ovl_override_sync_probe.krp));
+   p_ovl_override_sync_probe.krp.kp.symbol_name = P_OVL_OVERRIDE_SYNC_FUNC;
+   p_ovl_override_sync_probe.krp.handler = p_ovl_override_sync_ret;
+   p_ovl_override_sync_probe.krp.entry_handler = p_ovl_override_sync_entry;
+   p_ovl_override_sync_probe.krp.maxactive = p_get_kprobe_maxactive();
 }
 
 int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
@@ -43,8 +43,6 @@
 
 extern struct lkrg_probe p_ovl_override_sync_probe;
 
-int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(ovl_override_sync)
 void p_reinit_ovl_override_sync_kretprobe(void);
 

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
@@ -41,11 +41,6 @@
 
 #if P_OVL_OVERRIDE_SYNC_MODE
 
-/* per-instance private data */
-struct p_ovl_override_sync_data {
-    ktime_t entry_stamp;
-};
-
 extern char p_ovl_override_sync_kretprobe_state;
 
 int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
@@ -41,7 +41,7 @@
 
 #if P_OVL_OVERRIDE_SYNC_MODE
 
-extern char p_ovl_override_sync_kretprobe_state;
+extern struct lkrg_probe p_ovl_override_sync_probe;
 
 int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
@@ -45,8 +45,7 @@ extern struct lkrg_probe p_ovl_override_sync_probe;
 
 int p_ovl_override_sync_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_ovl_override_sync_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_ovl_override_sync_hook(int p_isra);
-void p_uninstall_ovl_override_sync_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(ovl_override_sync)
 void p_reinit_ovl_override_sync_kretprobe(void);
 
 #endif

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -24,12 +24,13 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-char p_override_creds_kretprobe_state = 0;
-
-static struct kretprobe p_override_creds_kretprobe = {
+static struct lkrg_probe p_override_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "override_creds",
     .handler = p_override_creds_ret,
     .entry_handler = p_override_creds_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -24,17 +24,7 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-static struct lkrg_probe p_override_creds_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "override_creds",
-    .handler = p_override_creds_ret,
-    .entry_handler = p_override_creds_entry,
-  }
-};
-
-
-notrace int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static notrace int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -58,8 +48,7 @@ notrace int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_re
    return 0;
 }
 
-
-notrace int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static notrace int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -73,6 +62,14 @@ notrace int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *
    return 0;
 }
 
+static struct lkrg_probe p_override_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "override_creds",
+    .handler = p_override_creds_ret,
+    .entry_handler = p_override_creds_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(override_creds)
 

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.c
@@ -30,7 +30,6 @@ static struct kretprobe p_override_creds_kretprobe = {
     .kp.symbol_name = "override_creds",
     .handler = p_override_creds_ret,
     .entry_handler = p_override_creds_entry,
-    .data_size = sizeof(struct p_override_creds_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
@@ -25,11 +25,6 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-/* per-instance private data */
-struct p_override_creds_data {
-    ktime_t entry_stamp;
-};
-
 int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_override_creds_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
@@ -25,8 +25,6 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(override_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_override_creds/p_override_creds.h
@@ -27,8 +27,7 @@
 
 int p_override_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_override_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_override_creds_hook(int p_isra);
-void p_uninstall_override_creds_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(override_creds)
 
 #endif
 #endif

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -23,17 +23,7 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-static struct lkrg_probe p_revert_creds_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "revert_creds",
-    .handler = p_revert_creds_ret,
-    .entry_handler = p_revert_creds_entry,
-  }
-};
-
-
-notrace int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static notrace int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
 #ifdef P_LKRG_TASK_OFF_DEBUG
    struct p_ed_process *p_tmp;
@@ -48,8 +38,7 @@ notrace int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs
    return 0;
 }
 
-
-notrace int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static notrace int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -65,6 +54,14 @@ notrace int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_
    return 0;
 }
 
+static struct lkrg_probe p_revert_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "revert_creds",
+    .handler = p_revert_creds_ret,
+    .entry_handler = p_revert_creds_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(revert_creds)
 

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -29,7 +29,6 @@ static struct kretprobe p_revert_creds_kretprobe = {
     .kp.symbol_name = "revert_creds",
     .handler = p_revert_creds_ret,
     .entry_handler = p_revert_creds_entry,
-    .data_size = sizeof(struct p_revert_creds_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.c
@@ -23,12 +23,13 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-char p_revert_creds_kretprobe_state = 0;
-
-static struct kretprobe p_revert_creds_kretprobe = {
+static struct lkrg_probe p_revert_creds_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "revert_creds",
     .handler = p_revert_creds_ret,
     .entry_handler = p_revert_creds_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
@@ -24,8 +24,6 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(revert_creds)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
@@ -24,11 +24,6 @@
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
 
-/* per-instance private data */
-struct p_revert_creds_data {
-    ktime_t entry_stamp;
-};
-
 int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_revert_creds_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
+++ b/src/modules/exploit_detection/syscalls/override/p_revert_creds/p_revert_creds.h
@@ -26,8 +26,7 @@
 
 int p_revert_creds_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_revert_creds_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_revert_creds_hook(int p_isra);
-void p_uninstall_revert_creds_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(revert_creds)
 
 #endif
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -27,7 +27,6 @@ static struct kretprobe p_pcfi___queue_work_kretprobe = {
     .kp.symbol_name = "__queue_work",
     .handler = p_pcfi___queue_work_ret,
     .entry_handler = p_pcfi___queue_work_entry,
-    .data_size = sizeof(struct p_pcfi___queue_work_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -20,27 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_pcfi___queue_work_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "__queue_work",
-    .kp.pre_handler = p_pcfi___queue_work_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -57,5 +37,12 @@ int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_pcfi___queue_work_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "__queue_work",
+    .kp.pre_handler = p_pcfi___queue_work_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(pcfi___queue_work)

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_pcfi___queue_work_kretprobe_state = 0;
-
-static struct kretprobe p_pcfi___queue_work_kretprobe = {
+static struct lkrg_probe p_pcfi___queue_work_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "__queue_work",
     .handler = p_pcfi___queue_work_ret,
     .entry_handler = p_pcfi___queue_work_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -21,11 +21,10 @@
 #include "../../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_pcfi___queue_work_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "__queue_work",
-    .handler = p_pcfi___queue_work_ret,
-    .entry_handler = p_pcfi___queue_work_entry,
+    .kp.pre_handler = p_pcfi___queue_work_entry,
   }
 };
 
@@ -41,7 +40,7 @@ static struct lkrg_probe p_pcfi___queue_work_probe = {
  *    r9  - 6th one
  */
 
-int p_pcfi___queue_work_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -54,14 +53,6 @@ int p_pcfi___queue_work_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-
-int p_pcfi___queue_work_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-//   p_ed_enforce_validation();
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
@@ -23,7 +23,6 @@
 
 
 int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_pcfi___queue_work_hook(int p_isra);
-void p_uninstall_pcfi___queue_work_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(pcfi___queue_work)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI___QUEUE_WORK_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI___QUEUE_WORK_H
 
-/* per-instance private data */
-struct p_pcfi___queue_work_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_pcfi___queue_work_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_pcfi___queue_work_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
@@ -21,8 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI___QUEUE_WORK_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI___QUEUE_WORK_H
 
-
-int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(pcfi___queue_work)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.h
@@ -22,8 +22,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_PCFI___QUEUE_WORK_H
 
 
-int p_pcfi___queue_work_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_pcfi___queue_work_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_pcfi___queue_work_hook(int p_isra);
 void p_uninstall_pcfi___queue_work_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
@@ -21,11 +21,10 @@
 #include "../../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_pcfi_lookup_fast_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "lookup_fast",
-    .handler = p_pcfi_lookup_fast_ret,
-    .entry_handler = p_pcfi_lookup_fast_entry,
+    .kp.pre_handler = p_pcfi_lookup_fast_entry,
   }
 };
 
@@ -41,7 +40,7 @@ static struct lkrg_probe p_pcfi_lookup_fast_probe = {
  *    r9  - 6th one
  */
 
-int p_pcfi_lookup_fast_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -58,14 +57,6 @@ int p_pcfi_lookup_fast_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-
-int p_pcfi_lookup_fast_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-//   p_ed_enforce_validation();
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
@@ -27,7 +27,6 @@ static struct kretprobe p_pcfi_lookup_fast_kretprobe = {
     .kp.symbol_name = "lookup_fast",
     .handler = p_pcfi_lookup_fast_ret,
     .entry_handler = p_pcfi_lookup_fast_entry,
-    .data_size = sizeof(struct p_pcfi_lookup_fast_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_pcfi_lookup_fast_kretprobe_state = 0;
-
-static struct kretprobe p_pcfi_lookup_fast_kretprobe = {
+static struct lkrg_probe p_pcfi_lookup_fast_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "lookup_fast",
     .handler = p_pcfi_lookup_fast_ret,
     .entry_handler = p_pcfi_lookup_fast_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.c
@@ -20,27 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_pcfi_lookup_fast_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "lookup_fast",
-    .kp.pre_handler = p_pcfi_lookup_fast_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -61,5 +41,12 @@ int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_pcfi_lookup_fast_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "lookup_fast",
+    .kp.pre_handler = p_pcfi_lookup_fast_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(pcfi_lookup_fast)

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
@@ -22,8 +22,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_LOOKUP_FAST_H
 
 
-int p_pcfi_lookup_fast_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_pcfi_lookup_fast_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_pcfi_lookup_fast_hook(int p_isra);
 void p_uninstall_pcfi_lookup_fast_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI_LOOKUP_FAST_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_LOOKUP_FAST_H
 
-/* per-instance private data */
-struct p_pcfi_lookup_fast_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_pcfi_lookup_fast_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_pcfi_lookup_fast_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
@@ -21,8 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI_LOOKUP_FAST_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_LOOKUP_FAST_H
 
-
-int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(pcfi_lookup_fast)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_lookup_fast/p_lookup_fast.h
@@ -23,7 +23,6 @@
 
 
 int p_pcfi_lookup_fast_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_pcfi_lookup_fast_hook(int p_isra);
-void p_uninstall_pcfi_lookup_fast_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(pcfi_lookup_fast)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_pcfi_mark_inode_dirty_kretprobe_state = 0;
-
-static struct kretprobe p_pcfi_mark_inode_dirty_kretprobe = {
+static struct lkrg_probe p_pcfi_mark_inode_dirty_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "__mark_inode_dirty",
     .handler = p_pcfi_mark_inode_dirty_ret,
     .entry_handler = p_pcfi_mark_inode_dirty_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
@@ -20,27 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_pcfi_mark_inode_dirty_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "__mark_inode_dirty",
-    .kp.pre_handler = p_pcfi_mark_inode_dirty_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -67,5 +47,12 @@ int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_pcfi_mark_inode_dirty_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "__mark_inode_dirty",
+    .kp.pre_handler = p_pcfi_mark_inode_dirty_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(pcfi_mark_inode_dirty)

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
@@ -27,7 +27,6 @@ static struct kretprobe p_pcfi_mark_inode_dirty_kretprobe = {
     .kp.symbol_name = "__mark_inode_dirty",
     .handler = p_pcfi_mark_inode_dirty_ret,
     .entry_handler = p_pcfi_mark_inode_dirty_entry,
-    .data_size = sizeof(struct p_pcfi_mark_inode_dirty_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.c
@@ -21,11 +21,10 @@
 #include "../../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_pcfi_mark_inode_dirty_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "__mark_inode_dirty",
-    .handler = p_pcfi_mark_inode_dirty_ret,
-    .entry_handler = p_pcfi_mark_inode_dirty_entry,
+    .kp.pre_handler = p_pcfi_mark_inode_dirty_entry,
   }
 };
 
@@ -41,7 +40,7 @@ static struct lkrg_probe p_pcfi_mark_inode_dirty_probe = {
  *    r9  - 6th one
  */
 
-int p_pcfi_mark_inode_dirty_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -64,13 +63,6 @@ int p_pcfi_mark_inode_dirty_entry(struct kretprobe_instance *p_ri, struct pt_reg
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-int p_pcfi_mark_inode_dirty_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-//   p_ed_enforce_validation();
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
@@ -22,8 +22,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_MARK_INODE_DIRTY_H
 
 
-int p_pcfi_mark_inode_dirty_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_pcfi_mark_inode_dirty_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_pcfi_mark_inode_dirty_hook(int p_isra);
 void p_uninstall_pcfi_mark_inode_dirty_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
@@ -23,7 +23,6 @@
 
 
 int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_pcfi_mark_inode_dirty_hook(int p_isra);
-void p_uninstall_pcfi_mark_inode_dirty_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(pcfi_mark_inode_dirty)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
@@ -21,8 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI_MARK_INODE_DIRTY_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_MARK_INODE_DIRTY_H
 
-
-int p_pcfi_mark_inode_dirty_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(pcfi_mark_inode_dirty)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_mark_inode_dirty/p_mark_inode_dirty.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI_MARK_INODE_DIRTY_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_MARK_INODE_DIRTY_H
 
-/* per-instance private data */
-struct p_pcfi_mark_inode_dirty_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_pcfi_mark_inode_dirty_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_pcfi_mark_inode_dirty_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
@@ -21,11 +21,10 @@
 #include "../../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_pcfi_schedule_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "schedule",
-    .handler = p_pcfi_schedule_ret,
-    .entry_handler = p_pcfi_schedule_entry,
+    .kp.pre_handler = p_pcfi_schedule_entry,
   }
 };
 
@@ -41,7 +40,7 @@ static struct lkrg_probe p_pcfi_schedule_probe = {
  *    r9  - 6th one
  */
 
-int p_pcfi_schedule_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -55,14 +54,6 @@ int p_pcfi_schedule_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-
-int p_pcfi_schedule_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-//   p_ed_enforce_validation();
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
@@ -20,27 +20,7 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_pcfi_schedule_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "schedule",
-    .kp.pre_handler = p_pcfi_schedule_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -58,5 +38,12 @@ int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_pcfi_schedule_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "schedule",
+    .kp.pre_handler = p_pcfi_schedule_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(pcfi_schedule)

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
@@ -20,13 +20,13 @@
 
 #include "../../../../../p_lkrg_main.h"
 
-
-char p_pcfi_schedule_kretprobe_state = 0;
-
-static struct kretprobe p_pcfi_schedule_kretprobe = {
+static struct lkrg_probe p_pcfi_schedule_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "schedule",
     .handler = p_pcfi_schedule_ret,
     .entry_handler = p_pcfi_schedule_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.c
@@ -27,7 +27,6 @@ static struct kretprobe p_pcfi_schedule_kretprobe = {
     .kp.symbol_name = "schedule",
     .handler = p_pcfi_schedule_ret,
     .entry_handler = p_pcfi_schedule_entry,
-    .data_size = sizeof(struct p_pcfi_schedule_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
@@ -22,8 +22,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_SCHEDULE_H
 
 
-int p_pcfi_schedule_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_pcfi_schedule_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_pcfi_schedule_hook(int p_isra);
 void p_uninstall_pcfi_schedule_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
@@ -21,8 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI_SCHEDULE_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_SCHEDULE_H
 
-
-int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(pcfi_schedule)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
@@ -23,7 +23,6 @@
 
 
 int p_pcfi_schedule_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_pcfi_schedule_hook(int p_isra);
-void p_uninstall_pcfi_schedule_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(pcfi_schedule)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
+++ b/src/modules/exploit_detection/syscalls/pCFI/p_schedule/p_schedule.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_PCFI_SCHEDULE_H
 #define P_LKRG_EXPLOIT_DETECTION_PCFI_SCHEDULE_H
 
-/* per-instance private data */
-struct p_pcfi_schedule_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_pcfi_schedule_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_pcfi_schedule_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -58,7 +58,6 @@ static const char * const p_umh_global[] = {
 
 static int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
-   struct p_ed_process *p_tmp;
    struct subprocess_info *p_subproc = (struct subprocess_info *)p_regs_get_arg1(p_regs);
    unsigned char p_umh_allowed = 0;
    size_t i;
@@ -69,31 +68,6 @@ static int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct p
       goto p_call_usermodehelper_entry_out;
    } else if (P_CTRL(p_umh_validate) == 2) {
       goto p_call_usermodehelper_entry_not_allowed;
-   }
-   if ((p_tmp = ed_task_lock_current())) {
-      /*
-       * Dirty hack to allow "off" to be set a second time from our hook of
-       * security_bprm_committing_creds().
-       *
-       * We do this before rather than after p_set_ed_process_off() here to
-       * work around known glitching where we'd be accessing a wrong ed task
-       * record here (as well as later).
-       *
-       * These hacks force p_set_ed_process_off() to take the "override" path
-       * both here and in the second call (from the later hook), so that it
-       * doesn't conflict with "off" possibly already being set for the task.
-       *
-       * FIXME: Figure out and fix the glitch, so that we'd access the right
-       * task record here, then at least move the flag_sync_thread++ to after
-       * p_set_ed_process_off() and maybe also rename it to reflect it's not
-       * only for seccomp, or alternatively stop setting "off" here (which may
-       * then be unneeded because call_usermodehelper_exec_async() itself only
-       * updates the capability sets, which we don't yet track).
-       */
-      p_tmp->p_ed_task.p_sec.flag_sync_thread++;
-      // This process is on the ED list - set temporary 'disable' flag!
-      p_set_ed_process_off(p_tmp);
-      ed_task_unlock(p_tmp);
    }
 
    for (i = 0; i < nitems(p_umh_global); i++) {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -21,9 +21,9 @@
 
 #include "../../../../p_lkrg_main.h"
 
-char p_call_usermodehelper_kretprobe_state = 0;
-
-static struct kretprobe p_call_usermodehelper_kretprobe = {
+static struct lkrg_probe p_call_usermodehelper_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
     .kp.symbol_name = "____call_usermodehelper",
 #else
@@ -31,6 +31,7 @@ static struct kretprobe p_call_usermodehelper_kretprobe = {
 #endif
     .handler = p_call_usermodehelper_ret,
     .entry_handler = p_call_usermodehelper_entry,
+  }
 };
 
 static const char * const p_umh_global[] = {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -21,19 +21,6 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_call_usermodehelper_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
-    .kp.symbol_name = "____call_usermodehelper",
-#else
-    .kp.symbol_name = "call_usermodehelper_exec_async",
-#endif
-    .handler = p_call_usermodehelper_ret,
-    .entry_handler = p_call_usermodehelper_entry,
-  }
-};
-
 static const char * const p_umh_global[] = {
    UMH_UNIFIFW
    UMH_LNET_UPCALL
@@ -69,7 +56,7 @@ static const char * const p_umh_global[] = {
    "/usr/share/apport/apport",
 };
 
-int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    struct subprocess_info *p_subproc = (struct subprocess_info *)p_regs_get_arg1(p_regs);
@@ -162,13 +149,24 @@ p_call_usermodehelper_entry_out:
    return 0;
 }
 
-
-int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    p_ed_enforce_validation();
 
    return 0;
 }
 
+static struct lkrg_probe p_call_usermodehelper_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
+    .kp.symbol_name = "____call_usermodehelper",
+#else
+    .kp.symbol_name = "call_usermodehelper_exec_async",
+#endif
+    .handler = p_call_usermodehelper_ret,
+    .entry_handler = p_call_usermodehelper_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(call_usermodehelper)

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.c
@@ -31,7 +31,6 @@ static struct kretprobe p_call_usermodehelper_kretprobe = {
 #endif
     .handler = p_call_usermodehelper_ret,
     .entry_handler = p_call_usermodehelper_entry,
-    .data_size = sizeof(struct p_call_usermodehelper_data),
 };
 
 static const char * const p_umh_global[] = {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
@@ -24,7 +24,6 @@
 
 int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_call_usermodehelper_hook(int p_isra);
-void p_uninstall_call_usermodehelper_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(call_usermodehelper)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
@@ -22,8 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_H
 #define P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_H
 
-int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(call_usermodehelper)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper/p_call_usermodehelper.h
@@ -22,11 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_H
 #define P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_H
 
-/* per-instance private data */
-struct p_call_usermodehelper_data {
-    ktime_t entry_stamp;
-};
-
 int p_call_usermodehelper_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_call_usermodehelper_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_call_usermodehelper_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
@@ -22,15 +22,14 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_call_usermodehelper_exec_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "call_usermodehelper_exec",
-    .handler = p_call_usermodehelper_exec_ret,
-    .entry_handler = p_call_usermodehelper_exec_entry,
+    .kp.pre_handler = p_call_usermodehelper_exec_entry,
   }
 };
 
-int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -43,11 +42,6 @@ int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-int p_call_usermodehelper_exec_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
@@ -28,7 +28,6 @@ static struct kretprobe p_call_usermodehelper_exec_kretprobe = {
     .kp.symbol_name = "call_usermodehelper_exec",
     .handler = p_call_usermodehelper_exec_ret,
     .entry_handler = p_call_usermodehelper_exec_entry,
-    .data_size = sizeof(struct p_call_usermodehelper_exec_data),
 };
 
 int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
@@ -21,15 +21,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_call_usermodehelper_exec_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "call_usermodehelper_exec",
-    .kp.pre_handler = p_call_usermodehelper_exec_entry,
-  }
-};
-
-int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -46,5 +38,12 @@ int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs
    return 0;
 }
 
+static struct lkrg_probe p_call_usermodehelper_exec_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "call_usermodehelper_exec",
+    .kp.pre_handler = p_call_usermodehelper_exec_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(call_usermodehelper_exec)

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.c
@@ -21,13 +21,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_call_usermodehelper_exec_kretprobe_state = 0;
-
-static struct kretprobe p_call_usermodehelper_exec_kretprobe = {
+static struct lkrg_probe p_call_usermodehelper_exec_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "call_usermodehelper_exec",
     .handler = p_call_usermodehelper_exec_ret,
     .entry_handler = p_call_usermodehelper_exec_entry,
+  }
 };
 
 int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
@@ -22,7 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 #define P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 
-int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(call_usermodehelper_exec)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
@@ -22,11 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 #define P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 
-/* per-instance private data */
-struct p_call_usermodehelper_exec_data {
-    ktime_t entry_stamp;
-};
-
 int p_call_usermodehelper_exec_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_call_usermodehelper_exec_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
@@ -23,7 +23,6 @@
 #define P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 
 int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_call_usermodehelper_exec_hook(int p_isra);
-void p_uninstall_call_usermodehelper_exec_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(call_usermodehelper_exec)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
+++ b/src/modules/exploit_detection/syscalls/p_call_usermodehelper_exec/p_call_usermodehelper_exec.h
@@ -22,8 +22,7 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 #define P_LKRG_EXPLOIT_DETECTION_CALL_USERMODEHELPER_EXEC_H
 
-int p_call_usermodehelper_exec_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_call_usermodehelper_exec_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_call_usermodehelper_exec_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_call_usermodehelper_exec_hook(int p_isra);
 void p_uninstall_call_usermodehelper_exec_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
@@ -20,27 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_capable_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "security_capable",
-    .kp.pre_handler = p_capable_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp = NULL;
 
@@ -59,5 +39,12 @@ int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_capable_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "security_capable",
+    .kp.pre_handler = p_capable_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(capable)

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
@@ -21,11 +21,10 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_capable_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "security_capable",
-    .handler = p_capable_ret,
-    .entry_handler = p_capable_entry,
+    .kp.pre_handler = p_capable_entry,
   }
 };
 
@@ -41,7 +40,7 @@ static struct lkrg_probe p_capable_probe = {
  *    r9  - 6th one
  */
 
-int p_capable_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp = NULL;
 
@@ -56,12 +55,6 @@ int p_capable_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-
-int p_capable_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_capable_kretprobe_state = 0;
-
-static struct kretprobe p_capable_kretprobe = {
+static struct lkrg_probe p_capable_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "security_capable",
     .handler = p_capable_ret,
     .entry_handler = p_capable_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.c
@@ -27,7 +27,6 @@ static struct kretprobe p_capable_kretprobe = {
     .kp.symbol_name = "security_capable",
     .handler = p_capable_ret,
     .entry_handler = p_capable_entry,
-    .data_size = sizeof(struct p_capable_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
@@ -22,8 +22,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_CAPABLE_H
 
 
-int p_capable_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_capable_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_capable_hook(int p_isra);
 void p_uninstall_capable_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
@@ -21,8 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CAPABLE_H
 #define P_LKRG_EXPLOIT_DETECTION_CAPABLE_H
 
-
-int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(capable)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_CAPABLE_H
 #define P_LKRG_EXPLOIT_DETECTION_CAPABLE_H
 
-/* per-instance private data */
-struct p_capable_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_capable_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_capable_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
+++ b/src/modules/exploit_detection/syscalls/p_capable/p_capable.h
@@ -23,7 +23,6 @@
 
 
 int p_capable_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_capable_hook(int p_isra);
-void p_uninstall_capable_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(capable)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
@@ -21,13 +21,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_do_exit_kretprobe_state = 0;
-
-static struct kretprobe p_do_exit_kretprobe = {
+static struct lkrg_probe p_do_exit_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "do_exit",
     .handler = p_do_exit_ret,
     .entry_handler = p_do_exit_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
@@ -28,7 +28,6 @@ static struct kretprobe p_do_exit_kretprobe = {
     .kp.symbol_name = "do_exit",
     .handler = p_do_exit_ret,
     .entry_handler = p_do_exit_entry,
-    .data_size = sizeof(struct p_do_exit_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
@@ -22,16 +22,15 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_do_exit_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "do_exit",
-    .handler = p_do_exit_ret,
-    .entry_handler = p_do_exit_entry,
+    .kp.pre_handler = p_do_exit_entry,
   }
 };
 
 
-int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    p_debug_kprobe_log(
           "p_do_exit_entry: comm[%s] Pid:%d",current->comm,current->pid);
 
@@ -42,14 +41,6 @@ int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    }
 
    /* A dump_stack() here will give a stack backtrace */
-   return 0;
-}
-
-
-int p_do_exit_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
-
-   p_ed_enforce_validation();
-
    return 0;
 }
 

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.c
@@ -21,16 +21,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_do_exit_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "do_exit",
-    .kp.pre_handler = p_do_exit_entry,
-  }
-};
-
-
-int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    p_debug_kprobe_log(
           "p_do_exit_entry: comm[%s] Pid:%d",current->comm,current->pid);
 
@@ -44,5 +35,12 @@ int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_do_exit_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "do_exit",
+    .kp.pre_handler = p_do_exit_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(do_exit)

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
@@ -22,8 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_DO_EXIT_H
 #define P_LKRG_EXPLOIT_DETECTION_DO_EXIT_H
 
-
-int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(do_exit)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
@@ -22,11 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_DO_EXIT_H
 #define P_LKRG_EXPLOIT_DETECTION_DO_EXIT_H
 
-/* per-instance private data */
-struct p_do_exit_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_do_exit_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
@@ -23,8 +23,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_DO_EXIT_H
 
 
-int p_do_exit_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_do_exit_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_do_exit_hook(int p_isra);
 void p_uninstall_do_exit_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
+++ b/src/modules/exploit_detection/syscalls/p_do_exit/p_do_exit.h
@@ -24,7 +24,6 @@
 
 
 int p_do_exit_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_do_exit_hook(int p_isra);
-void p_uninstall_do_exit_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(do_exit)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
@@ -38,13 +38,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_generic_permission_kretprobe_state = 0;
-
-static struct kretprobe p_generic_permission_kretprobe = {
+static struct lkrg_probe p_generic_permission_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "generic_permission",
     .handler = p_generic_permission_ret,
     .entry_handler = p_generic_permission_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
@@ -38,27 +38,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_generic_permission_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "generic_permission",
-    .kp.pre_handler = p_generic_permission_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp = NULL;
 
@@ -76,5 +56,12 @@ int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_generic_permission_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "generic_permission",
+    .kp.pre_handler = p_generic_permission_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(generic_permission)

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
@@ -39,11 +39,10 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_generic_permission_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "generic_permission",
-    .handler = p_generic_permission_ret,
-    .entry_handler = p_generic_permission_entry,
+    .kp.pre_handler = p_generic_permission_entry,
   }
 };
 
@@ -59,7 +58,7 @@ static struct lkrg_probe p_generic_permission_probe = {
  *    r9  - 6th one
  */
 
-int p_generic_permission_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp = NULL;
 
@@ -73,12 +72,6 @@ int p_generic_permission_entry(struct kretprobe_instance *p_ri, struct pt_regs *
          ed_task_unlock(p_tmp);
       }
    }
-
-   return 0;
-}
-
-
-int p_generic_permission_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.c
@@ -45,7 +45,6 @@ static struct kretprobe p_generic_permission_kretprobe = {
     .kp.symbol_name = "generic_permission",
     .handler = p_generic_permission_ret,
     .entry_handler = p_generic_permission_entry,
-    .data_size = sizeof(struct p_generic_permission_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
@@ -39,8 +39,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_GENERIC_PERMISSION_H
 #define P_LKRG_EXPLOIT_DETECTION_GENERIC_PERMISSION_H
 
-
-int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(generic_permission)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
@@ -40,8 +40,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_GENERIC_PERMISSION_H
 
 
-int p_generic_permission_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_generic_permission_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_generic_permission_hook(int p_isra);
 void p_uninstall_generic_permission_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
@@ -41,7 +41,6 @@
 
 
 int p_generic_permission_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_generic_permission_hook(int p_isra);
-void p_uninstall_generic_permission_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(generic_permission)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
+++ b/src/modules/exploit_detection/syscalls/p_generic_permission/p_generic_permission.h
@@ -39,11 +39,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_GENERIC_PERMISSION_H
 #define P_LKRG_EXPLOIT_DETECTION_GENERIC_PERMISSION_H
 
-/* per-instance private data */
-struct p_generic_permission_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_generic_permission_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_generic_permission_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_install.c
+++ b/src/modules/exploit_detection/syscalls/p_install.c
@@ -30,77 +30,79 @@ int p_get_kprobe_maxactive(void) {
    return max_t(unsigned int, 40, 2*num_possible_cpus());
 }
 
+static int p_register_probe(struct lkrg_probe *probe)
+{
+   if (probe->type == LKRG_KPROBE)
+      return register_kprobe(&probe->krp.kp);
+   return register_kretprobe(&probe->krp);
+}
+
+static void p_unregister_probe(struct lkrg_probe *probe)
+{
+   if (probe->type == LKRG_KPROBE)
+      unregister_kprobe(&probe->krp.kp);
+   else
+      unregister_kretprobe(&probe->krp);
+}
+
 int p_install_hook(struct lkrg_probe *probe, int p_isra) {
 
    int p_ret;
-   struct kretprobe *kretprobe = &probe->krp;
-   const char *p_name = kretprobe->kp.symbol_name;
+   const char *p_name = probe->krp.kp.symbol_name;
    struct p_isra_argument p_isra_arg;
 
-   kretprobe->maxactive = p_get_kprobe_maxactive();
-   if ( (p_ret = register_kretprobe(kretprobe)) < 0) {
+   if (probe->type == LKRG_KRETPROBE)
+      probe->krp.maxactive = p_get_kprobe_maxactive();
+   if ( (p_ret = p_register_probe(probe)) < 0) {
       if (p_isra && p_ret == -22) {
-         p_print_log(P_LOG_ISSUE, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
-                     p_name, p_ret);
-         p_print_log(P_LOG_WATCH, "Trying to find ISRA / CONSTPROP name for <%s>", p_name);
+         p_print_log(P_LOG_ISSUE, "register_k[ret]probe() for %s failed! [err=%d]", p_name, p_ret);
+         p_print_log(P_LOG_WATCH, "Trying to find ISRA / CONSTPROP name for %s", p_name);
          p_isra_arg.p_name = p_name;
          p_isra_arg.p_isra_name = NULL;
          if (p_try_isra_name(&p_isra_arg)) {
-            p_name = kretprobe->kp.symbol_name = p_isra_arg.p_isra_name;
-            if ( (p_ret = register_kretprobe(kretprobe)) < 0) {
+            p_name = probe->krp.kp.symbol_name = p_isra_arg.p_isra_name;
+            if ( (p_ret = p_register_probe(probe)) < 0) {
 /*
  * We use ISSUE rather than perhaps FATAL here because p_exploit_detection.c
  * does not expose the p_fatal flag in here and some of these are non-fatal.
  */
-               p_print_log(P_LOG_ISSUE, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
-                      p_name, p_ret);
+               p_print_log(P_LOG_ISSUE, "register_k[ret]probe() for %s failed! [err=%d]", p_name, p_ret);
                return p_ret;
             }
-            p_print_log(P_LOG_ISSUE, "ISRA / CONSTPROP version was found and hook was planted at <%s>",
-                        p_name);
+            p_print_log(P_LOG_ISSUE, "ISRA / CONSTPROP version was found and hook was planted for %s", p_name);
             probe->state = LKRG_PROBE_ISRA;
          } else {
-            p_print_log(P_LOG_ISSUE,
-                   "[kretprobe] register_kretprobe() for %s failed and ISRA / CONSTPROP version not found!",
-                   p_isra_arg.p_name);
+            p_print_log(P_LOG_ISSUE, "register_k[ret]probe() for %s failed and ISRA / CONSTPROP version not found!",
+                        p_isra_arg.p_name);
             return p_ret;
          }
       } else {
-         p_print_log(P_LOG_ISSUE, "[kretprobe] register_kretprobe() for <%s> failed! [err=%d]",
-                     p_name, p_ret);
+         p_print_log(P_LOG_ISSUE, "register_k[ret]probe() for %s failed! [err=%d]", p_name, p_ret);
          return p_ret;
       }
    } else {
       probe->state = LKRG_PROBE_ON;
    }
 
-   p_print_log(P_LOG_WATCH, "Planted [kretprobe] <%s> at: 0x%lx",
-               p_name,
-               (unsigned long)kretprobe->kp.addr);
+   p_print_log(P_LOG_WATCH, "Planted k[ret]probe %s at 0x%lx", p_name, (unsigned long)probe->krp.kp.addr);
 
    return p_ret;
 }
 
 void p_uninstall_hook(struct lkrg_probe *probe) {
 
-   struct kretprobe *kretprobe = &probe->krp;
-   const char *p_name = kretprobe->kp.symbol_name;
+   const char *p_name = probe->krp.kp.symbol_name;
 
    if (probe->state == LKRG_PROBE_OFF) {
-      p_print_log(P_LOG_WATCH, "[kretprobe] <%s> at 0x%lx is NOT installed",
-                  p_name,
-                  (unsigned long)kretprobe->kp.addr);
+      p_print_log(P_LOG_WATCH, "k[ret]probe for %s is NOT installed", p_name);
    } else {
-      unregister_kretprobe(kretprobe);
-      p_print_log(P_LOG_WATCH, "Removing [kretprobe] <%s> at 0x%lx nmissed[%d]",
-                  p_name,
-                  (unsigned long)kretprobe->kp.addr,
-                  kretprobe->nmissed);
+      p_unregister_probe(probe);
+      p_print_log(P_LOG_WATCH, "Removed k[ret]probe for %s at 0x%lx nmissed %d %lu",
+                  p_name, (unsigned long)probe->krp.kp.addr, probe->krp.nmissed, probe->krp.kp.nmissed);
       if (probe->state == LKRG_PROBE_ISRA) {
          // Free ISRA name buffer
-         p_print_log(P_LOG_WATCH, "Freeing ISRA / CONSTPROP buffer[0x%lx]",
-                     (unsigned long)kretprobe->kp.symbol_name);
-         kfree(kretprobe->kp.symbol_name);
+         p_print_log(P_LOG_WATCH, "Freeing ISRA / CONSTPROP buffer [0x%lx]", (unsigned long)p_name);
+         kfree(p_name);
       }
       probe->state = LKRG_PROBE_OFF;
    }

--- a/src/modules/exploit_detection/syscalls/p_install.c
+++ b/src/modules/exploit_detection/syscalls/p_install.c
@@ -30,9 +30,10 @@ int p_get_kprobe_maxactive(void) {
    return max_t(unsigned int, 40, 2*num_possible_cpus());
 }
 
-int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
+int p_install_hook(struct lkrg_probe *probe, int p_isra) {
 
    int p_ret;
+   struct kretprobe *kretprobe = &probe->krp;
    const char *p_name = kretprobe->kp.symbol_name;
    struct p_isra_argument p_isra_arg;
 
@@ -57,7 +58,7 @@ int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
             }
             p_print_log(P_LOG_ISSUE, "ISRA / CONSTPROP version was found and hook was planted at <%s>",
                         p_name);
-            (*state)++;
+            probe->state = LKRG_PROBE_ISRA;
          } else {
             p_print_log(P_LOG_ISSUE,
                    "[kretprobe] register_kretprobe() for %s failed and ISRA / CONSTPROP version not found!",
@@ -69,21 +70,23 @@ int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra) {
                      p_name, p_ret);
          return p_ret;
       }
+   } else {
+      probe->state = LKRG_PROBE_ON;
    }
 
    p_print_log(P_LOG_WATCH, "Planted [kretprobe] <%s> at: 0x%lx",
                p_name,
                (unsigned long)kretprobe->kp.addr);
-   (*state)++;
 
    return p_ret;
 }
 
-void p_uninstall_hook(struct kretprobe *kretprobe, char *state) {
+void p_uninstall_hook(struct lkrg_probe *probe) {
 
+   struct kretprobe *kretprobe = &probe->krp;
    const char *p_name = kretprobe->kp.symbol_name;
 
-   if (!*state) {
+   if (probe->state == LKRG_PROBE_OFF) {
       p_print_log(P_LOG_WATCH, "[kretprobe] <%s> at 0x%lx is NOT installed",
                   p_name,
                   (unsigned long)kretprobe->kp.addr);
@@ -93,12 +96,12 @@ void p_uninstall_hook(struct kretprobe *kretprobe, char *state) {
                   p_name,
                   (unsigned long)kretprobe->kp.addr,
                   kretprobe->nmissed);
-      if (*state == 2) {
+      if (probe->state == LKRG_PROBE_ISRA) {
          // Free ISRA name buffer
          p_print_log(P_LOG_WATCH, "Freeing ISRA / CONSTPROP buffer[0x%lx]",
                      (unsigned long)kretprobe->kp.symbol_name);
          kfree(kretprobe->kp.symbol_name);
       }
-      *state = 0;
+      probe->state = LKRG_PROBE_OFF;
    }
 }

--- a/src/modules/exploit_detection/syscalls/p_install.h
+++ b/src/modules/exploit_detection/syscalls/p_install.h
@@ -23,7 +23,7 @@
 
 struct lkrg_probe {
    enum { LKRG_PROBE_OFF, LKRG_PROBE_ON, LKRG_PROBE_ISRA } state;
-   enum { LKRG_KRETPROBE } type;
+   enum { LKRG_KPROBE, LKRG_KRETPROBE } type;
    struct kretprobe krp;
 };
 

--- a/src/modules/exploit_detection/syscalls/p_install.h
+++ b/src/modules/exploit_detection/syscalls/p_install.h
@@ -21,18 +21,24 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_INSTALL_H
 #define P_LKRG_EXPLOIT_DETECTION_INSTALL_H
 
+struct lkrg_probe {
+   enum { LKRG_PROBE_OFF, LKRG_PROBE_ON, LKRG_PROBE_ISRA } state;
+   enum { LKRG_KRETPROBE } type;
+   struct kretprobe krp;
+};
+
 int p_get_kprobe_maxactive(void);
 
-int p_install_hook(struct kretprobe *kretprobe, char *state, int p_isra);
-void p_uninstall_hook(struct kretprobe *kretprobe, char *state);
+int p_install_hook(struct lkrg_probe *probe, int p_isra);
+void p_uninstall_hook(struct lkrg_probe *probe);
 
 #define GENERATE_INSTALL_FUNC(name)                                                       \
    int p_install_##name##_hook(int p_isra) {                                              \
-      return p_install_hook(&p_##name##_kretprobe, &p_##name##_kretprobe_state, p_isra);  \
+      return p_install_hook(&p_##name##_probe, p_isra);                                   \
    }                                                                                      \
                                                                                           \
    void p_uninstall_##name##_hook(void) {                                                 \
-      return p_uninstall_hook(&p_##name##_kretprobe, &p_##name##_kretprobe_state);        \
+      return p_uninstall_hook(&p_##name##_probe);                                         \
    }
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_install.h
+++ b/src/modules/exploit_detection/syscalls/p_install.h
@@ -41,4 +41,8 @@ void p_uninstall_hook(struct lkrg_probe *probe);
       return p_uninstall_hook(&p_##name##_probe);                                         \
    }
 
+#define GENERATE_INSTALL_FUNC_PROTO(name) \
+   extern int p_install_##name##_hook(int p_isra); \
+   extern void p_uninstall_##name##_hook(void);
+
 #endif

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
@@ -21,6 +21,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
+static int p_scm_send_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+
+   p_ed_enforce_validation();
+
+   return 0;
+}
+
 static struct lkrg_probe p_scm_send_probe = {
   .type = LKRG_KPROBE,
   .krp = {
@@ -28,14 +35,5 @@ static struct lkrg_probe p_scm_send_probe = {
     .kp.pre_handler = p_scm_send_entry,
   }
 };
-
-
-int p_scm_send_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
-
-   p_ed_enforce_validation();
-
-   return 0;
-}
-
 
 GENERATE_INSTALL_FUNC(scm_send)

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
@@ -22,24 +22,17 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_scm_send_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "__scm_send",
-    .handler = p_scm_send_ret,
-    .entry_handler = p_scm_send_entry,
+    .kp.pre_handler = p_scm_send_entry,
   }
 };
 
 
-int p_scm_send_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_scm_send_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    p_ed_enforce_validation();
-
-   return 0;
-}
-
-
-int p_scm_send_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
@@ -28,7 +28,6 @@ static struct kretprobe p_scm_send_kretprobe = {
     .kp.symbol_name = "__scm_send",
     .handler = p_scm_send_ret,
     .entry_handler = p_scm_send_entry,
-    .data_size = sizeof(struct p_scm_send_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.c
@@ -21,13 +21,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_scm_send_kretprobe_state = 0;
-
-static struct kretprobe p_scm_send_kretprobe = {
+static struct lkrg_probe p_scm_send_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "__scm_send",
     .handler = p_scm_send_ret,
     .entry_handler = p_scm_send_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
@@ -24,7 +24,6 @@
 
 
 int p_scm_send_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_scm_send_hook(int p_isra);
-void p_uninstall_scm_send_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(scm_send)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
@@ -22,8 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SCM_SEND_H
 #define P_LKRG_EXPLOIT_DETECTION_SCM_SEND_H
 
-
-int p_scm_send_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(scm_send)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
@@ -23,8 +23,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_SCM_SEND_H
 
 
-int p_scm_send_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_scm_send_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_scm_send_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_scm_send_hook(int p_isra);
 void p_uninstall_scm_send_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
+++ b/src/modules/exploit_detection/syscalls/p_scm_send/p_scm_send.h
@@ -22,11 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SCM_SEND_H
 #define P_LKRG_EXPLOIT_DETECTION_SCM_SEND_H
 
-/* per-instance private data */
-struct p_scm_send_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_scm_send_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_scm_send_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
@@ -21,9 +21,9 @@
 #include "../../../../p_lkrg_main.h"
 
 #if defined(P_LKRG_EXPLOIT_DETECTION_SECCOMP_H)
-char p_seccomp_kretprobe_state = 0;
-
-static struct kretprobe p_seccomp_kretprobe = {
+static struct lkrg_probe p_seccomp_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
     .kp.symbol_name = "do_seccomp",
 #else
@@ -32,6 +32,7 @@ static struct kretprobe p_seccomp_kretprobe = {
     .handler = p_seccomp_ret,
     .entry_handler = p_seccomp_entry,
     .data_size = sizeof(struct p_seccomp_data),
+  }
 };
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.c
@@ -21,19 +21,6 @@
 #include "../../../../p_lkrg_main.h"
 
 #if defined(P_LKRG_EXPLOIT_DETECTION_SECCOMP_H)
-static struct lkrg_probe p_seccomp_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-    .kp.symbol_name = "do_seccomp",
-#else
-    .kp.symbol_name = "prctl_set_seccomp",
-#endif
-    .handler = p_seccomp_ret,
-    .entry_handler = p_seccomp_entry,
-    .data_size = sizeof(struct p_seccomp_data),
-  }
-};
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 static __always_inline void p_seccomp_filter_tsync(bool entry) {
@@ -83,6 +70,11 @@ static __always_inline void p_seccomp_filter_tsync(bool entry) {
 }
 #endif
 
+/* per-instance private data */
+struct p_seccomp_data {
+   unsigned int filter_flags;
+};
+
 static __always_inline void p_handle_seccomp(struct p_seccomp_data *priv, struct pt_regs *p_regs, bool entry) {
 
    struct p_ed_process *p_tmp;
@@ -104,31 +96,32 @@ static __always_inline void p_handle_seccomp(struct p_seccomp_data *priv, struct
    }
 }
 
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_seccomp_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_seccomp_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    p_handle_seccomp((void *)p_ri->data, p_regs, true);
    return 0;
 }
 
-
-int p_seccomp_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_seccomp_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    p_handle_seccomp((void *)p_ri->data, p_regs, false);
    return 0;
 }
 
+static struct lkrg_probe p_seccomp_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+    .kp.symbol_name = "do_seccomp",
+#else
+    .kp.symbol_name = "prctl_set_seccomp",
+#endif
+    .handler = p_seccomp_ret,
+    .entry_handler = p_seccomp_entry,
+    .data_size = sizeof(struct p_seccomp_data),
+  }
+};
 
 GENERATE_INSTALL_FUNC(seccomp)
+
 #endif

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.h
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.h
@@ -31,8 +31,7 @@ struct p_seccomp_data {
 
 int p_seccomp_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_seccomp_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_seccomp_hook(int p_isra);
-void p_uninstall_seccomp_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(seccomp)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.h
+++ b/src/modules/exploit_detection/syscalls/p_seccomp/p_seccomp.h
@@ -23,14 +23,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECCOMP_H
 #define P_LKRG_EXPLOIT_DETECTION_SECCOMP_H
 
-/* per-instance private data */
-struct p_seccomp_data {
-   unsigned int filter_flags;
-};
-
-
-int p_seccomp_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_seccomp_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(seccomp)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_security_ptrace_access_kretprobe_state = 0;
-
-static struct kretprobe p_security_ptrace_access_kretprobe = {
+static struct lkrg_probe p_security_ptrace_access_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "security_ptrace_access_check",
     .handler = p_security_ptrace_access_ret,
     .entry_handler = p_security_ptrace_access_entry,
+  }
 };
 
 int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
@@ -27,7 +27,6 @@ static struct kretprobe p_security_ptrace_access_kretprobe = {
     .kp.symbol_name = "security_ptrace_access_check",
     .handler = p_security_ptrace_access_ret,
     .entry_handler = p_security_ptrace_access_entry,
-    .data_size = sizeof(struct p_security_ptrace_access_data),
 };
 
 int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
@@ -20,15 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_security_ptrace_access_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "security_ptrace_access_check",
-    .kp.pre_handler = p_security_ptrace_access_entry,
-  }
-};
-
-int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    if ((p_tmp = ed_task_lock_current())) {
@@ -42,5 +34,12 @@ int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs) 
    return 0;
 }
 
+static struct lkrg_probe p_security_ptrace_access_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "security_ptrace_access_check",
+    .kp.pre_handler = p_security_ptrace_access_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(security_ptrace_access)

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.c
@@ -21,15 +21,14 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_security_ptrace_access_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "security_ptrace_access_check",
-    .handler = p_security_ptrace_access_ret,
-    .entry_handler = p_security_ptrace_access_entry,
+    .kp.pre_handler = p_security_ptrace_access_entry,
   }
 };
 
-int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    if ((p_tmp = ed_task_lock_current())) {
@@ -39,14 +38,6 @@ int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_re
    }
 
    p_ed_enforce_validation();
-
-   return 0;
-}
-
-
-int p_security_ptrace_access_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
-
-//   p_ed_enforce_validation();
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
@@ -22,7 +22,6 @@
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 
 int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_security_ptrace_access_hook(int p_isra);
-void p_uninstall_security_ptrace_access_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(security_ptrace_access)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
@@ -21,10 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 
-struct p_security_ptrace_access_data {
-    ktime_t entry_stamp;
-};
-
 int p_security_ptrace_access_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_install_security_ptrace_access_hook(int p_isra);

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
@@ -21,7 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 
-int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(security_ptrace_access)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
+++ b/src/modules/exploit_detection/syscalls/p_security_ptrace_access/p_security_ptrace_access.h
@@ -21,8 +21,7 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 #define P_LKRG_EXPLOIT_DETECTION_SECURITY_PTRACE_ACCESS_H
 
-int p_security_ptrace_access_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_security_ptrace_access_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_security_ptrace_access_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_security_ptrace_access_hook(int p_isra);
 void p_uninstall_security_ptrace_access_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
@@ -29,7 +29,6 @@ static struct kretprobe p_sel_write_enforce_kretprobe = {
     .kp.symbol_name = "sel_write_enforce",
     .handler = p_sel_write_enforce_ret,
     .entry_handler = p_sel_write_enforce_entry,
-    .data_size = sizeof(struct p_sel_write_enforce_data),
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
@@ -23,28 +23,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sel_write_enforce_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "sel_write_enforce",
-    .handler = p_sel_write_enforce_ret,
-    .entry_handler = p_sel_write_enforce_entry,
-  }
-};
-
-/*
- * x86-64 syscall ABI:
- *  *rax - syscall_number
- *    rdi - 1st argument
- *    rsi - 2nd argument
- *    rdx - 3rd argument
- *    rcx - 4th argument
- *
- *    r8  - 5th one
- *    r9  - 6th one
- */
-
-int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
    if ((p_tmp = ed_task_lock_current())) {
@@ -63,8 +42,7 @@ int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    return 0;
 }
 
-
-int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    // Success ?
    if (!IS_ERR((void *)p_regs_get_ret(p_regs))) {
@@ -86,6 +64,14 @@ int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_r
    return 0;
 }
 
+static struct lkrg_probe p_sel_write_enforce_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "sel_write_enforce",
+    .handler = p_sel_write_enforce_ret,
+    .entry_handler = p_sel_write_enforce_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sel_write_enforce)
 

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.c
@@ -23,12 +23,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-char p_sel_write_enforce_kretprobe_state = 0;
-
-static struct kretprobe p_sel_write_enforce_kretprobe = {
+static struct lkrg_probe p_sel_write_enforce_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "sel_write_enforce",
     .handler = p_sel_write_enforce_ret,
     .entry_handler = p_sel_write_enforce_entry,
+  }
 };
 
 /*

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.h
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.h
@@ -23,10 +23,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SEL_WRITE_ENFORCE_H
 #define P_LKRG_EXPLOIT_DETECTION_SEL_WRITE_ENFORCE_H
 
-
-
-int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sel_write_enforce)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.h
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.h
@@ -24,11 +24,6 @@
 #define P_LKRG_EXPLOIT_DETECTION_SEL_WRITE_ENFORCE_H
 
 
-/* per-instance private data */
-struct p_sel_write_enforce_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.h
+++ b/src/modules/exploit_detection/syscalls/p_sel_write_enforce/p_sel_write_enforce.h
@@ -27,8 +27,7 @@
 
 int p_sel_write_enforce_ret(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 int p_sel_write_enforce_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sel_write_enforce_hook(int p_isra);
-void p_uninstall_sel_write_enforce_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sel_write_enforce)
 
 #endif
 

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_set_current_groups_kretprobe_state = 0;
-
-static struct kretprobe p_set_current_groups_kretprobe = {
+static struct lkrg_probe p_set_current_groups_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "set_current_groups",
     .handler = p_set_current_groups_ret,
     .entry_handler = p_set_current_groups_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
@@ -27,7 +27,6 @@ static struct kretprobe p_set_current_groups_kretprobe = {
     .kp.symbol_name = "set_current_groups",
     .handler = p_set_current_groups_ret,
     .entry_handler = p_set_current_groups_entry,
-    .data_size = sizeof(struct p_set_current_groups_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_set_current_groups_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = "set_current_groups",
-    .handler = p_set_current_groups_ret,
-    .entry_handler = p_set_current_groups_entry,
-  }
-};
-
-
-int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *
    return 0;
 }
 
-
-int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -71,5 +60,14 @@ int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_re
 
    return 0;
 }
+
+static struct lkrg_probe p_set_current_groups_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = "set_current_groups",
+    .handler = p_set_current_groups_ret,
+    .entry_handler = p_set_current_groups_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(set_current_groups)

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.h
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.h
@@ -24,7 +24,6 @@
 
 int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_set_current_groups_hook(int p_isra);
-void p_uninstall_set_current_groups_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(set_current_groups)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.h
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SET_CURRENT_GROUPS_H
 #define P_LKRG_EXPLOIT_DETECTION_SET_CURRENT_GROUPS_H
 
-
-int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(set_current_groups)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.h
+++ b/src/modules/exploit_detection/syscalls/p_set_current_groups/p_set_current_groups.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SET_CURRENT_GROUPS_H
 #define P_LKRG_EXPLOIT_DETECTION_SET_CURRENT_GROUPS_H
 
-/* per-instance private data */
-struct p_set_current_groups_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_set_current_groups_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_set_current_groups_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setfsgid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setfsgid_kretprobe = {
+static struct lkrg_probe p_sys_setfsgid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setfsgid),
     .handler = p_sys_setfsgid_ret,
     .entry_handler = p_sys_setfsgid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setfsgid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setfsgid),
     .handler = p_sys_setfsgid_ret,
     .entry_handler = p_sys_setfsgid_entry,
-    .data_size = sizeof(struct p_sys_setfsgid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setfsgid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setfsgid),
-    .handler = p_sys_setfsgid_ret,
-    .entry_handler = p_sys_setfsgid_entry,
-  }
-};
-
-
-int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -51,8 +41,7 @@ int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    return 0;
 }
 
-
-int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -74,5 +63,13 @@ int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setfsgid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setfsgid),
+    .handler = p_sys_setfsgid_ret,
+    .entry_handler = p_sys_setfsgid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setfsgid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETFSGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETFSGID_H
 
-
-int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setfsgid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETFSGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETFSGID_H
 
-/* per-instance private data */
-struct p_sys_setfsgid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsgid/p_sys_setfsgid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setfsgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setfsgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setfsgid_hook(int p_isra);
-void p_uninstall_sys_setfsgid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setfsgid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setfsuid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setfsuid),
-    .handler = p_sys_setfsuid_ret,
-    .entry_handler = p_sys_setfsuid_entry,
-  }
-};
-
-
-int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -51,8 +41,7 @@ int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    return 0;
 }
 
-
-int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -74,5 +63,13 @@ int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setfsuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setfsuid),
+    .handler = p_sys_setfsuid_ret,
+    .entry_handler = p_sys_setfsuid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setfsuid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setfsuid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setfsuid),
     .handler = p_sys_setfsuid_ret,
     .entry_handler = p_sys_setfsuid_entry,
-    .data_size = sizeof(struct p_sys_setfsuid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setfsuid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setfsuid_kretprobe = {
+static struct lkrg_probe p_sys_setfsuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setfsuid),
     .handler = p_sys_setfsuid_ret,
     .entry_handler = p_sys_setfsuid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETFSUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETFSUID_H
 
-
-int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setfsuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETFSUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETFSUID_H
 
-/* per-instance private data */
-struct p_sys_setfsuid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setfsuid/p_sys_setfsuid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setfsuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setfsuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setfsuid_hook(int p_isra);
-void p_uninstall_sys_setfsuid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setfsuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setgid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setgid_kretprobe = {
+static struct lkrg_probe p_sys_setgid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setgid),
     .handler = p_sys_setgid_ret,
     .entry_handler = p_sys_setgid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setgid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setgid),
-    .handler = p_sys_setgid_ret,
-    .entry_handler = p_sys_setgid_entry,
-  }
-};
-
-
-int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    return 0;
 }
 
-
-int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setgid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setgid),
+    .handler = p_sys_setgid_ret,
+    .entry_handler = p_sys_setgid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setgid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setgid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setgid),
     .handler = p_sys_setgid_ret,
     .entry_handler = p_sys_setgid_entry,
-    .data_size = sizeof(struct p_sys_setgid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setgid_hook(int p_isra);
-void p_uninstall_sys_setgid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setgid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETGID_H
 
-/* per-instance private data */
-struct p_sys_setgid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setgid/p_sys_setgid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETGID_H
 
-
-int p_sys_setgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setgid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setns_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setns_kretprobe = {
+static struct lkrg_probe p_sys_setns_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(setns),
     .handler = p_sys_setns_ret,
     .entry_handler = p_sys_setns_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setns_kretprobe = {
     .kp.symbol_name = P_GET_SYSCALL_NAME(setns),
     .handler = p_sys_setns_ret,
     .entry_handler = p_sys_setns_entry,
-    .data_size = sizeof(struct p_sys_setns_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setns_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SYSCALL_NAME(setns),
-    .handler = p_sys_setns_ret,
-    .entry_handler = p_sys_setns_entry,
-  }
-};
-
-
-int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
-
-int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setns_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SYSCALL_NAME(setns),
+    .handler = p_sys_setns_ret,
+    .entry_handler = p_sys_setns_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setns)

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETNS_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETNS_H
 
-
-int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setns)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.h
@@ -24,7 +24,6 @@
 
 int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setns_hook(int p_isra);
-void p_uninstall_sys_setns_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setns)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setns/p_sys_setns.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETNS_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETNS_H
 
-/* per-instance private data */
-struct p_sys_setns_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setns_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setns_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setregid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setregid),
     .handler = p_sys_setregid_ret,
     .entry_handler = p_sys_setregid_entry,
-    .data_size = sizeof(struct p_sys_setregid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setregid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setregid_kretprobe = {
+static struct lkrg_probe p_sys_setregid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setregid),
     .handler = p_sys_setregid_ret,
     .entry_handler = p_sys_setregid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setregid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setregid),
-    .handler = p_sys_setregid_ret,
-    .entry_handler = p_sys_setregid_entry,
-  }
-};
-
-
-int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    return 0;
 }
 
-
-int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setregid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setregid),
+    .handler = p_sys_setregid_ret,
+    .entry_handler = p_sys_setregid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setregid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETREGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETREGID_H
 
-
-int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setregid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setregid_hook(int p_isra);
-void p_uninstall_sys_setregid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setregid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setregid/p_sys_setregid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETREGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETREGID_H
 
-/* per-instance private data */
-struct p_sys_setregid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setregid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setregid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setresgid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setresgid_kretprobe = {
+static struct lkrg_probe p_sys_setresgid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setresgid),
     .handler = p_sys_setresgid_ret,
     .entry_handler = p_sys_setresgid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setresgid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setresgid),
-    .handler = p_sys_setresgid_ret,
-    .entry_handler = p_sys_setresgid_entry,
-  }
-};
-
-
-int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
    return 0;
 }
 
-
-int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setresgid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setresgid),
+    .handler = p_sys_setresgid_ret,
+    .entry_handler = p_sys_setresgid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setresgid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setresgid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setresgid),
     .handler = p_sys_setresgid_ret,
     .entry_handler = p_sys_setresgid_entry,
-    .data_size = sizeof(struct p_sys_setresgid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setresgid_hook(int p_isra);
-void p_uninstall_sys_setresgid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setresgid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETRESGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETRESGID_H
 
-
-int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setresgid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresgid/p_sys_setresgid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETRESGID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETRESGID_H
 
-/* per-instance private data */
-struct p_sys_setresgid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setresgid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setresgid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setresuid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setresuid_kretprobe = {
+static struct lkrg_probe p_sys_setresuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setresuid),
     .handler = p_sys_setresuid_ret,
     .entry_handler = p_sys_setresuid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setresuid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setresuid),
     .handler = p_sys_setresuid_ret,
     .entry_handler = p_sys_setresuid_entry,
-    .data_size = sizeof(struct p_sys_setresuid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setresuid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setresuid),
-    .handler = p_sys_setresuid_ret,
-    .entry_handler = p_sys_setresuid_entry,
-  }
-};
-
-
-int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_reg
    return 0;
 }
 
-
-int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setresuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setresuid),
+    .handler = p_sys_setresuid_ret,
+    .entry_handler = p_sys_setresuid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setresuid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETRESUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETRESUID_H
 
-
-int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setresuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETRESUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETRESUID_H
 
-/* per-instance private data */
-struct p_sys_setresuid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setresuid/p_sys_setresuid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setresuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setresuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setresuid_hook(int p_isra);
-void p_uninstall_sys_setresuid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setresuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setreuid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setreuid_kretprobe = {
+static struct lkrg_probe p_sys_setreuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setreuid),
     .handler = p_sys_setreuid_ret,
     .entry_handler = p_sys_setreuid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setreuid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setreuid),
     .handler = p_sys_setreuid_ret,
     .entry_handler = p_sys_setreuid_entry,
-    .data_size = sizeof(struct p_sys_setreuid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setreuid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setreuid),
-    .handler = p_sys_setreuid_ret,
-    .entry_handler = p_sys_setreuid_entry,
-  }
-};
-
-
-int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs
    return 0;
 }
 
-
-int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setreuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setreuid),
+    .handler = p_sys_setreuid_ret,
+    .entry_handler = p_sys_setreuid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setreuid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETREUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETREUID_H
 
-
-int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setreuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETREUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETREUID_H
 
-/* per-instance private data */
-struct p_sys_setreuid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setreuid/p_sys_setreuid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setreuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setreuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setreuid_hook(int p_isra);
-void p_uninstall_sys_setreuid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setreuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
@@ -20,13 +20,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_setuid_kretprobe_state = 0;
-
-static struct kretprobe p_sys_setuid_kretprobe = {
+static struct lkrg_probe p_sys_setuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setuid),
     .handler = p_sys_setuid_ret,
     .entry_handler = p_sys_setuid_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
@@ -27,7 +27,6 @@ static struct kretprobe p_sys_setuid_kretprobe = {
     .kp.symbol_name = P_GET_SET_ID_NAME(setuid),
     .handler = p_sys_setuid_ret,
     .entry_handler = p_sys_setuid_entry,
-    .data_size = sizeof(struct p_sys_setuid_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.c
@@ -20,17 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_setuid_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-    .kp.symbol_name = P_GET_SET_ID_NAME(setuid),
-    .handler = p_sys_setuid_ret,
-    .entry_handler = p_sys_setuid_entry,
-  }
-};
-
-
-int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -47,8 +37,7 @@ int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) 
    return 0;
 }
 
-
-int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -72,5 +61,13 @@ int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_setuid_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+    .kp.symbol_name = P_GET_SET_ID_NAME(setuid),
+    .handler = p_sys_setuid_ret,
+    .entry_handler = p_sys_setuid_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_setuid)

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETUID_H
 
-
-int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_setuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_SETUID_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_SETUID_H
 
-/* per-instance private data */
-struct p_sys_setuid_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_setuid/p_sys_setuid.h
@@ -24,7 +24,6 @@
 
 int p_sys_setuid_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_setuid_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_setuid_hook(int p_isra);
-void p_uninstall_sys_setuid_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_setuid)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
@@ -20,21 +20,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_sys_unshare_probe = {
-  .type = LKRG_KRETPROBE,
-  .krp = {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)
-    .kp.symbol_name = "ksys_unshare",
-#else
-    .kp.symbol_name = "sys_unshare",
-#endif
-    .handler = p_sys_unshare_ret,
-    .entry_handler = p_sys_unshare_entry,
-  }
-};
-
-
-int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+static int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -51,8 +37,7 @@ int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs)
    return 0;
 }
 
-
-int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
+static int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    struct p_ed_process *p_tmp;
 
@@ -76,5 +61,17 @@ int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_sys_unshare_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)
+    .kp.symbol_name = "ksys_unshare",
+#else
+    .kp.symbol_name = "sys_unshare",
+#endif
+    .handler = p_sys_unshare_ret,
+    .entry_handler = p_sys_unshare_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(sys_unshare)

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
@@ -31,7 +31,6 @@ static struct kretprobe p_sys_unshare_kretprobe = {
 #endif
     .handler = p_sys_unshare_ret,
     .entry_handler = p_sys_unshare_entry,
-    .data_size = sizeof(struct p_sys_unshare_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.c
@@ -20,10 +20,9 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_sys_unshare_kretprobe_state = 0;
-
-static struct kretprobe p_sys_unshare_kretprobe = {
+static struct lkrg_probe p_sys_unshare_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)
     .kp.symbol_name = "ksys_unshare",
 #else
@@ -31,6 +30,7 @@ static struct kretprobe p_sys_unshare_kretprobe = {
 #endif
     .handler = p_sys_unshare_ret,
     .entry_handler = p_sys_unshare_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.h
@@ -24,7 +24,6 @@
 
 int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-int p_install_sys_unshare_hook(int p_isra);
-void p_uninstall_sys_unshare_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(sys_unshare)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.h
@@ -21,9 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_UNSHARE_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_UNSHARE_H
 
-
-int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(sys_unshare)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.h
+++ b/src/modules/exploit_detection/syscalls/p_sys_unshare/p_sys_unshare.h
@@ -21,11 +21,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_SYS_UNSHARE_H
 #define P_LKRG_EXPLOIT_DETECTION_SYS_UNSHARE_H
 
-/* per-instance private data */
-struct p_sys_unshare_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_sys_unshare_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_sys_unshare_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -22,16 +22,15 @@
 #include "../../../../p_lkrg_main.h"
 
 static struct lkrg_probe p_wake_up_new_task_probe = {
-  .type = LKRG_KRETPROBE,
+  .type = LKRG_KPROBE,
   .krp = {
     .kp.symbol_name = "wake_up_new_task",
-    .handler = p_wake_up_new_task_ret,
-    .entry_handler = p_wake_up_new_task_entry,
+    .kp.pre_handler = p_wake_up_new_task_entry,
   }
 };
 
 
-int p_wake_up_new_task_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
+int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct task_struct *p_task = (struct task_struct *)p_regs_get_arg1(p_regs);
    struct p_ed_process *p_tmp;
@@ -58,14 +57,6 @@ int p_wake_up_new_task_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_
    }
 
    p_ed_enforce_validation();
-
-   return 0;
-}
-
-
-int p_wake_up_new_task_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
-
-//   p_ed_enforce_validation();
 
    return 0;
 }

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -21,16 +21,7 @@
 
 #include "../../../../p_lkrg_main.h"
 
-static struct lkrg_probe p_wake_up_new_task_probe = {
-  .type = LKRG_KPROBE,
-  .krp = {
-    .kp.symbol_name = "wake_up_new_task",
-    .kp.pre_handler = p_wake_up_new_task_entry,
-  }
-};
-
-
-int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
+static int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
 
    struct task_struct *p_task = (struct task_struct *)p_regs_get_arg1(p_regs);
    struct p_ed_process *p_tmp;
@@ -61,5 +52,12 @@ int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs) {
    return 0;
 }
 
+static struct lkrg_probe p_wake_up_new_task_probe = {
+  .type = LKRG_KPROBE,
+  .krp = {
+    .kp.symbol_name = "wake_up_new_task",
+    .kp.pre_handler = p_wake_up_new_task_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(wake_up_new_task)

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -21,13 +21,13 @@
 
 #include "../../../../p_lkrg_main.h"
 
-
-char p_wake_up_new_task_kretprobe_state = 0;
-
-static struct kretprobe p_wake_up_new_task_kretprobe = {
+static struct lkrg_probe p_wake_up_new_task_probe = {
+  .type = LKRG_KRETPROBE,
+  .krp = {
     .kp.symbol_name = "wake_up_new_task",
     .handler = p_wake_up_new_task_ret,
     .entry_handler = p_wake_up_new_task_entry,
+  }
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -28,7 +28,6 @@ static struct kretprobe p_wake_up_new_task_kretprobe = {
     .kp.symbol_name = "wake_up_new_task",
     .handler = p_wake_up_new_task_ret,
     .entry_handler = p_wake_up_new_task_entry,
-    .data_size = sizeof(struct p_wake_up_new_task_data),
 };
 
 

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
@@ -24,7 +24,6 @@
 
 
 int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
-int p_install_wake_up_new_task_hook(int p_isra);
-void p_uninstall_wake_up_new_task_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(wake_up_new_task)
 
 #endif

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
@@ -22,11 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_WAKE_UP_NEW_TASK_H
 #define P_LKRG_EXPLOIT_DETECTION_WAKE_UP_NEW_TASK_H
 
-/* per-instance private data */
-struct p_wake_up_new_task_data {
-    ktime_t entry_stamp;
-};
-
 
 int p_wake_up_new_task_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 int p_wake_up_new_task_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
@@ -23,8 +23,7 @@
 #define P_LKRG_EXPLOIT_DETECTION_WAKE_UP_NEW_TASK_H
 
 
-int p_wake_up_new_task_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-int p_wake_up_new_task_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
+int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 int p_install_wake_up_new_task_hook(int p_isra);
 void p_uninstall_wake_up_new_task_hook(void);
 

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.h
@@ -22,8 +22,6 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_WAKE_UP_NEW_TASK_H
 #define P_LKRG_EXPLOIT_DETECTION_WAKE_UP_NEW_TASK_H
 
-
-int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs);
 GENERATE_INSTALL_FUNC_PROTO(wake_up_new_task)
 
 #endif

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
@@ -17,17 +17,7 @@
 
 #include "../../../p_lkrg_main.h"
 
-static int p_lkrg_dummy_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
-static int p_lkrg_dummy_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
-
-static struct lkrg_probe p_lkrg_dummy_probe = {
-  .type = LKRG_KRETPROBE,
-    .krp = {
-    .kp.symbol_name = "lkrg_dummy",
-    .handler = p_lkrg_dummy_ret,
-    .entry_handler = p_lkrg_dummy_entry,
-  }
-};
+static struct lkrg_probe p_lkrg_dummy_probe;
 
 #ifdef __clang__
 __attribute__((optnone))
@@ -46,7 +36,6 @@ static noinline int lkrg_dummy(int arg) {
 
    return arg+1;
 }
-
 
 int lkrg_verify_kprobes(void) {
 
@@ -72,11 +61,19 @@ static int p_lkrg_dummy_entry(struct kretprobe_instance *p_ri, struct pt_regs *p
    return 0;
 }
 
-
 static int p_lkrg_dummy_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs) {
 
    p_regs_set_ret(p_regs, p_regs_get_ret(p_regs) + 1);
    return 0;
 }
+
+static struct lkrg_probe p_lkrg_dummy_probe = {
+  .type = LKRG_KRETPROBE,
+    .krp = {
+    .kp.symbol_name = "lkrg_dummy",
+    .handler = p_lkrg_dummy_ret,
+    .entry_handler = p_lkrg_dummy_entry,
+  }
+};
 
 GENERATE_INSTALL_FUNC(lkrg_dummy)

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
@@ -20,12 +20,13 @@
 static int p_lkrg_dummy_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs);
 static int p_lkrg_dummy_ret(struct kretprobe_instance *ri, struct pt_regs *p_regs);
 
-static char p_lkrg_dummy_kretprobe_state = 0;
-
-static struct kretprobe p_lkrg_dummy_kretprobe = {
+static struct lkrg_probe p_lkrg_dummy_probe = {
+  .type = LKRG_KRETPROBE,
+    .krp = {
     .kp.symbol_name = "lkrg_dummy",
     .handler = p_lkrg_dummy_ret,
     .entry_handler = p_lkrg_dummy_entry,
+  }
 };
 
 #ifdef __clang__
@@ -51,7 +52,7 @@ int lkrg_verify_kprobes(void) {
 
    int p_ret = 0, ret = -1;
 
-   if (!p_lkrg_dummy_kretprobe_state)
+   if (p_lkrg_dummy_probe.state == LKRG_PROBE_OFF)
       return 0;
 
    /* Verify kprobes now */

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.h
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.h
@@ -20,7 +20,6 @@
 
 int lkrg_verify_kprobes(void);
 
-int p_install_lkrg_dummy_hook(int p_isra);
-void p_uninstall_lkrg_dummy_hook(void);
+GENERATE_INSTALL_FUNC_PROTO(lkrg_dummy)
 
 #endif

--- a/src/modules/kmod/p_kmod_notifier.c
+++ b/src/modules/kmod/p_kmod_notifier.c
@@ -254,7 +254,7 @@ p_module_event_notifier_activity_out:
 void p_verify_module_live(struct module *p_mod) {
 
 #if P_OVL_OVERRIDE_SYNC_MODE
-   if (p_ovl_override_sync_kretprobe_state) {
+   if (p_ovl_override_sync_probe.state != LKRG_PROBE_OFF) {
       /* We do not need to do anything for now */
       return;
    }
@@ -289,7 +289,7 @@ void p_verify_module_live(struct module *p_mod) {
 void p_verify_module_going(struct module *p_mod) {
 
 #if P_OVL_OVERRIDE_SYNC_MODE
-   if (!p_ovl_override_sync_kretprobe_state) {
+   if (p_ovl_override_sync_probe.state == LKRG_PROBE_OFF) {
       /* We do not need to do anything for now */
       return;
    }


### PR DESCRIPTION
### Description
This cleans up (and maybe speeds up) our use of kretprobes, introduces support for simple kprobes into our shared hooking functions, and actually switches many of the hooks to simple kprobes.

### How Has This Been Tested?
Works fine so far in the VM where I develop this. I also checked `log_level=4` messages.