### PR TITLE
Perform stricter cred pointer checks where no creds override is expected

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ The following major changes have been made since 0.9.9:
 
  *) Support Linux 6.13+ by not hooking {override,revert}_creds() anymore, and
     limiting detection of cred pointer overwrite attacks on those kernels
+ *) To compensate for the above and as an enhancement on older kernels, check
+    for cred pointer overwrites in certain other places where we did not before
  *) Switch many hooks from kretprobes to simple kprobes for greater reliability
     and improved performance
  *) Overhaul locking of per-task shadow data, using finer-grain locks

--- a/src/modules/database/CPU.c
+++ b/src/modules/database/CPU.c
@@ -70,7 +70,7 @@ int p_cmp_cpus(p_cpu_info *p_orig, p_cpu_info *p_current) {
    int p_flag = 0;
 
 #define P_CMP_CPU(which) \
-   if (p_orig->which ## _CPUs != p_current->which ## _CPUs) { \
+   if (unlikely(p_orig->which ## _CPUs != p_current->which ## _CPUs)) { \
       p_print_log(P_LOG_FAULT, "Number of " #which " CPUs changed unexpectedly (expected %u, actual %u)", \
          p_orig->which ## _CPUs, p_current->which ## _CPUs); \
       p_flag++; \
@@ -81,7 +81,7 @@ int p_cmp_cpus(p_cpu_info *p_orig, p_cpu_info *p_current) {
    P_CMP_CPU(present)
    P_CMP_CPU(active)
 
-   if (p_orig->p_nr_cpu_ids != p_current->p_nr_cpu_ids) {
+   if (unlikely(p_orig->p_nr_cpu_ids != p_current->p_nr_cpu_ids)) {
       p_print_log(P_LOG_FAULT, "'nr_cpu_ids' changed unexpectedly (expected %u, actual %u)",
          p_orig->p_nr_cpu_ids, p_current->p_nr_cpu_ids);
       p_flag++;

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1027,6 +1027,8 @@ notrace void p_ed_validate_off_flag_wrap(struct p_ed_process *p_source) {
    p_validate_off_flag(p_source,p_off,NULL);   // Validate
 }
 
+static inline void p_cmp_cred_ptr(struct p_ed_process *edp, bool full_check);
+
 notrace void p_set_ed_process_on(struct p_ed_process *p_source) {
 
    register unsigned long p_off = p_source->p_ed_task.p_off ^ p_global_off_cookie; // Decode
@@ -1041,6 +1043,8 @@ notrace void p_set_ed_process_on(struct p_ed_process *p_source) {
 
       p_source->p_ed_task.p_off = p_off ^ p_global_off_cookie; // Encode
       p_source->p_ed_task.p_off_count = 0;
+
+      p_cmp_cred_ptr(p_source, true);
 #if defined(CONFIG_SECCOMP)
    }
 #endif
@@ -1059,6 +1063,8 @@ notrace void p_set_ed_process_off(struct p_ed_process *p_source) {
       p_off += p_global_cnt_cookie;               // Normalize
 
       p_source->p_ed_task.p_off = p_off ^ p_global_off_cookie;
+
+      p_cmp_cred_ptr(p_source, false);
 #if defined(CONFIG_SECCOMP)
    }
 #endif
@@ -1438,6 +1444,29 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    put_cred(p_current_real_cred);
 
    return p_killed ? -p_ret : p_ret;
+}
+
+/*
+ * Compensate for the relaxed cred pointer checks in p_cmp_tasks() especially
+ * on 6.13+ by doing strict checks where no creds override is expected/allowed.
+ */
+static inline void p_cmp_cred_ptr(struct p_ed_process *edp, bool full_check) {
+
+   struct task_struct *p_current = edp->p_ed_task.p_task;
+   const struct cred *p_current_cred = p_current->cred;
+   const struct cred *p_current_real_cred = p_current->real_cred;
+   const char p_opt = 1; /* for uses of the P_CMP_PTR() macro */
+   int p_ret = 0;
+
+   if (full_check) {
+      P_CMP_PTR(edp->p_ed_task.p_cred_ptr, p_current_cred, "cred")
+      P_CMP_PTR(edp->p_ed_task.p_real_cred_ptr, p_current_real_cred, "real_cred")
+   }
+   if (likely(!p_ret))
+      P_CMP_PTR(p_current_real_cred, p_current_cred, "cred")
+
+   if (unlikely(p_ret))
+      p_ed_kill_task(edp);
 }
 
 static void p_ed_validate_kill(struct p_ed_process *p_source) {

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -494,7 +494,7 @@ notrace void p_verify_addr_limit(struct p_ed_process *p_orig) {
    struct task_struct *p_current = p_orig->p_ed_task.p_task;
 
    /* Verify addr_limit */
-   if (p_addr_limit != p_get_addr_limit(p_current)) {
+   if (unlikely(p_addr_limit != p_get_addr_limit(p_current))) {
       p_print_log(P_LOG_ALERT,
          "DETECT: Task: addr_limit corruption (expected 0x%lx vs. actual 0x%lx) for pid %u, name %s",
          p_addr_limit, p_get_addr_limit(p_current), task_pid_nr(p_current), p_current->comm);
@@ -1218,7 +1218,7 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_task) && p_get_task_state(p_task) != TASK_DEAD) {
          if ((p_tmp = ed_task_find_lock_rcu(p_task))) {
-            if (p_cmp_tasks(p_tmp, 0x0)) {
+            if (unlikely(p_cmp_tasks(p_tmp, 0x0))) {
                p_ret++;
                p_ed_kill_task(p_tmp);
             }
@@ -1244,7 +1244,7 @@ static int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred,
    int p_ret = 0;
 
 #define P_CMP_CRED(eq, get, cred) \
-   if (!eq(p_orig->cred, p_current_cred->cred)) { \
+   if (unlikely(!eq(p_orig->cred, p_current_cred->cred))) { \
       if (p_opt) { \
          p_print_log(P_LOG_ALERT, \
             "DETECT: Task: " #cred " corruption (expected %u vs. actual %u) for pid %u, name %s", \
@@ -1267,7 +1267,7 @@ static int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred,
    P_CMP_CRED(gid_eq, p_get_gid, fsgid)
 
 #define P_CMP_PTR(orig, curr, name) \
-   if (orig != curr) { \
+   if (unlikely(orig != curr)) { \
       if (p_opt) { \
          if (P_CTRL(p_log_level) >= P_LOG_WATCH) \
             p_print_log(P_LOG_ALERT, \
@@ -1305,7 +1305,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
 
       p_orig->p_ed_task.p_off_count++;
 
-      if (p_orig->p_ed_task.p_off_count > P_ED_PROCESS_OFF_MAX) {
+      if (unlikely(p_orig->p_ed_task.p_off_count > P_ED_PROCESS_OFF_MAX)) {
          /* That's weird and it might be a potentially compromised process */
          p_print_log(P_LOG_WATCH, "Validation was off %u times in a row for pid %u, name %s",
             p_orig->p_ed_task.p_off_count, p_orig->p_ed_task.p_pid, p_orig->p_ed_task.p_comm);
@@ -1314,7 +1314,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    }
 
    /* Validate stack first */
-   if (p_ed_pcfi_validate_sp(NULL, p_orig, p_get_thread_sp(p_current))) {
+   if (unlikely(p_ed_pcfi_validate_sp(NULL, p_orig, p_get_thread_sp(p_current)))) {
       if (p_kill) {
          p_pcfi_kill_ed_task(p_orig);
          p_killed = 1;
@@ -1346,7 +1346,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
     * legitimate, but uses of commit_creds() are not (we set our "off" flag on
     * the legitimate ones, so would not reach this function in those cases).
     */
-   if (p_orig->p_ed_task.p_cred_ptr != p_current_cred
+   if (unlikely(p_orig->p_ed_task.p_cred_ptr != p_current_cred)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
       && p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred
 #endif
@@ -1356,7 +1356,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
       }
    }
 
-   if (p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred) {
+   if (unlikely(p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred)) {
       if (p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x0)) {
          P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_real_cred, "real_cred")
       }
@@ -1366,7 +1366,8 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
     * Now (re-)check the credentials and report any differences.
     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
-   if (p_orig->p_ed_task.p_cred_ptr == p_current_cred || p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred)
+   if (likely(p_orig->p_ed_task.p_cred_ptr == p_current_cred) ||
+      unlikely(p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred))
 #endif
       p_ret += p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x1);
    p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x1);
@@ -1397,9 +1398,9 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    if (p_orig->p_ed_task.p_sec.flag) { // SECCOMP was enabled so it make sense to compare...
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0)
-      if (test_task_syscall_work(p_current,SECCOMP) != p_orig->p_ed_task.p_sec.flag) {
+      if (unlikely(test_task_syscall_work(p_current,SECCOMP) != p_orig->p_ed_task.p_sec.flag)) {
 #else
-      if (test_tsk_thread_flag(p_current,TIF_SECCOMP) != p_orig->p_ed_task.p_sec.flag) {
+      if (unlikely(test_tsk_thread_flag(p_current,TIF_SECCOMP) != p_orig->p_ed_task.p_sec.flag)) {
 #endif
          p_print_log(P_LOG_ALERT, "DETECT: Task: TIF_SECCOMP flag corruption (expected %u vs. actual %u) for pid %u, name %s",
             p_orig->p_ed_task.p_sec.flag,
@@ -1412,7 +1413,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
          p_ret++;
       }
 
-      if (p_orig->p_ed_task.p_sec.sec.mode != p_current->seccomp.mode) {
+      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_current->seccomp.mode)) {
          if (p_current->seccomp.mode < 0 || p_current->seccomp.mode > 2
              || p_orig->p_ed_task.p_sec.sec.mode < 0 || p_orig->p_ed_task.p_sec.sec.mode > 2) {
             p_print_log(P_LOG_ALERT, "DETECT: Task: seccomp mode corruption (expected %u vs. actual %u) for pid %u, name %s",
@@ -1441,7 +1442,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
 
 static void p_ed_validate_kill(struct p_ed_process *p_source) {
 
-   if (p_cmp_tasks(p_source, 1) > 0) {
+   if (unlikely(p_cmp_tasks(p_source, 1) > 0)) {
       // kill this process!
       p_ed_kill_task(p_source);
    }

--- a/src/modules/integrity_timer/p_integrity_timer.c
+++ b/src/modules/integrity_timer/p_integrity_timer.c
@@ -223,7 +223,7 @@ void p_check_integrity(struct work_struct *p_work) {
 
    p_tmp_hash = hash_from_CPU_data(p_tmp_cpus);
 
-   if (p_db.p_CPU_metadata_hashes != p_tmp_hash) {
+   if (unlikely(p_db.p_CPU_metadata_hashes != p_tmp_hash)) {
       /* I'm hacked! ;( */
       p_print_log(P_LOG_ALERT, "DETECT: CPU: Hash of CPU metadata has changed unexpectedly");
 #define P_KINT_IF_ACCEPT(old, new) \
@@ -240,7 +240,7 @@ void p_check_integrity(struct work_struct *p_work) {
    read_unlock(&p_config_lock);
 
    /* Verify kprobes now */
-   if (lkrg_verify_kprobes()) {
+   if (unlikely(lkrg_verify_kprobes())) {
       /* I'm hacked! ;( */
       p_hack_check++;
    }
@@ -276,7 +276,7 @@ void p_check_integrity(struct work_struct *p_work) {
       p_tmp_hash = p_lkrg_fast_hash((unsigned char *)p_db.kernel_ex_table.p_addr,
                                     (unsigned int)p_db.kernel_ex_table.p_size);
 
-      if (p_db.kernel_ex_table.p_hash != p_tmp_hash) {
+      if (unlikely(p_db.kernel_ex_table.p_hash != p_tmp_hash)) {
          /* I'm hacked! ;( */
          p_print_log(P_LOG_ALERT, "DETECT: Kernel: Exception table hash changed unexpectedly");
          P_KINT_IF_ACCEPT(p_db.kernel_ex_table.p_hash, p_tmp_hash)
@@ -293,7 +293,7 @@ void p_check_integrity(struct work_struct *p_work) {
    p_tmp_hash = p_lkrg_fast_hash((unsigned char *)p_db.kernel_stext.p_addr,
                                  (unsigned int)p_db.kernel_stext.p_size);
 
-   if (p_db.kernel_stext.p_hash != p_tmp_hash) {
+   if (unlikely(p_db.kernel_stext.p_hash != p_tmp_hash)) {
 #if defined(P_LKRG_JUMP_LABEL_STEXT_DEBUG)
       unsigned char *p_str1 = (unsigned char *)p_db.kernel_stext.p_addr;
       unsigned char *p_str2 = (unsigned char *)p_db.kernel_stext_copy;
@@ -333,7 +333,7 @@ void p_check_integrity(struct work_struct *p_work) {
       p_tmp_hash = 0xFFFFFFFF;
 #endif
 
-      if (p_db.kernel_rodata.p_hash != p_tmp_hash) {
+      if (unlikely(p_db.kernel_rodata.p_hash != p_tmp_hash)) {
          /* I'm hacked! ;( */
          p_print_log(P_LOG_ALERT, "DETECT: Kernel: _rodata hash changed unexpectedly");
          P_KINT_IF_ACCEPT(p_db.kernel_rodata.p_hash, p_tmp_hash)
@@ -356,7 +356,7 @@ void p_check_integrity(struct work_struct *p_work) {
       p_tmp_hash = 0xFFFFFFFF;
 #endif
 
-      if (p_db.kernel_iommu_table.p_hash != p_tmp_hash) {
+      if (unlikely(p_db.kernel_iommu_table.p_hash != p_tmp_hash)) {
          /* I'm hacked! ;( */
          p_print_log(P_LOG_ALERT, "DETECT: Kernel: IOMMU table hash changed unexpectedly");
          P_KINT_IF_ACCEPT(p_db.kernel_iommu_table.p_hash, p_tmp_hash)
@@ -380,7 +380,7 @@ void p_check_integrity(struct work_struct *p_work) {
     * TODO: dump as much info about this module as possible e.g.
     * core-dump image, ddebug_table information, symbol table, etc.
     */
-   if (p_module_list_nr_tmp != p_module_kobj_nr_tmp) {
+   if (unlikely(p_module_list_nr_tmp != p_module_kobj_nr_tmp)) {
       unsigned int p_tmp_cnt,p_tmp_diff = 0;
       char p_tmp_flag,p_tmp_flag_cnt = 0;
 
@@ -582,7 +582,7 @@ void p_check_integrity(struct work_struct *p_work) {
     * TODO: dump as much info about this module as possible e.g.
     * core-dump image, ddebug_table information, symbol table, etc.
     */
-   if (p_module_list_nr_tmp != p_db.p_module_list_nr) {
+   if (unlikely(p_module_list_nr_tmp != p_db.p_module_list_nr)) {
       unsigned int p_tmp_cnt,p_tmp_diff = 0;
       char p_tmp_flag,p_tmp_flag_cnt = 0;
 
@@ -734,7 +734,7 @@ void p_check_integrity(struct work_struct *p_work) {
     * TODO: dump as much info about this module as possible e.g.
     * core-dump image, ddebug_table information, symbol table, etc.
     */
-   if (p_module_kobj_nr_tmp != p_db.p_module_kobj_nr) {
+   if (unlikely(p_module_kobj_nr_tmp != p_db.p_module_kobj_nr)) {
       unsigned int p_tmp_cnt,p_tmp_diff = 0;
       char p_tmp_flag,p_tmp_flag_cnt = 0;
 
@@ -884,7 +884,7 @@ void p_check_integrity(struct work_struct *p_work) {
 
    p_print_log(P_LOG_WATCH, "Hash from 'module list' => [0x%llx]", p_tmp_hash);
 
-   if (p_tmp_hash != p_db.p_module_list_hash) {
+   if (unlikely(p_tmp_hash != p_db.p_module_list_hash)) {
       unsigned int p_tmp_cnt,p_local_hack_check = 0;
 
       for (p_tmp = 0; p_tmp < p_db.p_module_list_nr; p_tmp++) {
@@ -935,7 +935,7 @@ void p_check_integrity(struct work_struct *p_work) {
 
    p_print_log(P_LOG_WATCH, "Hash from 'module kobj(s)' => [0x%llx]", p_tmp_hash);
 
-   if (p_tmp_hash != p_db.p_module_kobj_hash) {
+   if (unlikely(p_tmp_hash != p_db.p_module_kobj_hash)) {
 
       /*
        * OK, we know hash will be different if there is inconsistency in the number

--- a/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
+++ b/src/modules/integrity_timer/verify_kprobes/p_verify_kprobes.c
@@ -45,7 +45,7 @@ int lkrg_verify_kprobes(void) {
       return 0;
 
    /* Verify kprobes now */
-   if ( (ret = lkrg_dummy(0)) != 3) {
+   if (unlikely((ret = lkrg_dummy(0)) != 3)) {
       /* I'm hacked! ;( */
       p_print_log(P_LOG_ALERT, "DETECT: Kprobes: Don't work as intended (disabled?)");
       p_ret = -1;


### PR DESCRIPTION
### Description

Two changes/commits here:

1. Wrap integrity violation checks in unlikely() - this is just something I happened to start working on while implementing the more important change:
2. Compensate for the relaxed cred pointer checks in p_cmp_tasks() especially on 6.13+ by stricter checks in places where we also assert that our `off` flag must be off. This corresponds to a subset of our hooks where no creds override is expected. We may later expand these checks to more places. See #371

### How Has This Been Tested?
In the VM where/while I worked on completing these changes, and in our CI under my personal GitHub account.