### PR TITLE
Support 6.16-rc, fix JUMP_LABEL batch indexing in hook of arch_jump_label_transform_apply

### DIFF
--- a/README
+++ b/README
@@ -11,8 +11,8 @@ RHEL7's (and its many clones/revisions) to latest mainline and distros kernels.
 
 LKRG 0.9.9 should work correctly with Linux kernels up to 6.12.y, and mostly
 with 6.13.y.  The current git revision has been updated to also work correctly
-with 6.13+.  We've tested it with Arch Linux's 6.14.3-arch1-1, and we expect it
-to also work with 6.15 once it's released.
+with 6.13+ and our CI setup has tested it with kernels up to Fedora's build of
+6.16.0-0.rc1.250613g27605c8c0f69.21.fc43.x86_64.
 
 LKRG currently supports the x86-64, 32-bit x86, AArch64 (ARM64), and 32-bit ARM
 CPU architectures.

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -39,7 +39,11 @@ static unsigned int p_jl_batch_nr;
 
 static notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_instance *p_ri, struct pt_regs *p_regs) {
 
+#ifdef TEXT_POKE_MAX_OPCODE_SIZE
+   int p_nr = P_SYM(p_text_poke_array)->nr_entries;
+#else
    int p_nr = *P_SYM(p_tp_vec_nr);
+#endif
    int p_cnt = 0;
    p_text_poke_loc *p_tmp;
 
@@ -60,7 +64,11 @@ static notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_inst
                "[JUMP_LABEL <batch mode>] New modifications => %d",p_nr);
 
    for (p_jl_batch_nr = 0; p_cnt < p_nr; p_cnt++) {
+#ifdef TEXT_POKE_MAX_OPCODE_SIZE
+      p_tmp = &P_SYM(p_text_poke_array)->vec[p_jl_batch_nr];
+#else
       p_tmp = (p_text_poke_loc *)&P_SYM(p_tp_vec)[p_jl_batch_nr*sizeof(p_text_poke_loc)];
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) || \
     defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)
       if ( (p_tmp->opcode == CALL_INSN_OPCODE

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -65,9 +65,9 @@ static notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_inst
 
    for (p_jl_batch_nr = 0; p_cnt < p_nr; p_cnt++) {
 #ifdef TEXT_POKE_MAX_OPCODE_SIZE
-      p_tmp = &P_SYM(p_text_poke_array)->vec[p_jl_batch_nr];
+      p_tmp = &P_SYM(p_text_poke_array)->vec[p_cnt];
 #else
-      p_tmp = (p_text_poke_loc *)&P_SYM(p_tp_vec)[p_jl_batch_nr*sizeof(p_text_poke_loc)];
+      p_tmp = &P_SYM(p_tp_vec)[p_cnt];
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0) || \
     defined(P_LKRG_KERNEL_RHEL_VAR_LEN_JUMP_LABEL)

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -87,6 +87,14 @@ typedef struct _p_text_poke_loc {
     /* see text_poke_bp_batch() */
     u8 old;
 } p_text_poke_loc;
+  #ifdef TEXT_POKE_MAX_OPCODE_SIZE
+   #define TEXT_POKE_ARRAY_MAX (PAGE_SIZE / sizeof(p_text_poke_loc))
+struct p_text_poke_array {
+    p_text_poke_loc vec[TEXT_POKE_ARRAY_MAX];
+    int nr_entries;
+};
+  #endif
+
  #endif
 #else
 typedef struct text_poke_loc p_text_poke_loc;

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h
@@ -78,7 +78,12 @@ typedef struct _p_text_poke_loc {
     s32 disp;
     u8 len;
     u8 opcode;
+/* The TEXT_POKE_MAX_OPCODE_SIZE name is used since 6.16-rc */
+  #ifdef TEXT_POKE_MAX_OPCODE_SIZE
+    const u8 text[TEXT_POKE_MAX_OPCODE_SIZE];
+  #else
     const u8 text[POKE_MAX_OPCODE_SIZE];
+  #endif
     /* see text_poke_bp_batch() */
     u8 old;
 } p_text_poke_loc;

--- a/src/modules/database/arch/p_arch_metadata.c
+++ b/src/modules/database/arch/p_arch_metadata.c
@@ -75,8 +75,12 @@ int p_register_arch_metadata(void) {
    /*
     * These symbols are used in our hook of arch_jump_label_transform_apply().
     */
+#ifdef TEXT_POKE_MAX_OPCODE_SIZE
+   P_SYM_INIT(text_poke_array)
+#else
    P_SYM_INIT(tp_vec)
    P_SYM_INIT(tp_vec_nr)
+#endif
 
    /*
     * This is not an arch specific hook, but it's a good place to register it

--- a/src/modules/wrap/p_struct_wrap.h
+++ b/src/modules/wrap/p_struct_wrap.h
@@ -453,7 +453,7 @@ static inline int p_set_memory_ro(unsigned long p_addr, int p_numpages) {
 #else
    return P_SYM(p_change_page_attr_set_clr)(&p_addr, p_numpages,
                                             __pgprot(0),
-                                            __pgprot(_PAGE_RW),
+                                            __pgprot(_PAGE_RW|_PAGE_DIRTY),
                                             0, 0, NULL);
 #endif
 }

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -237,8 +237,12 @@ typedef struct _p_lkrg_global_symbols_structure {
 #ifdef CONFIG_TRACEPOINTS
    struct mutex *p_tracepoints_mutex;
 #endif
+#ifdef TEXT_POKE_MAX_OPCODE_SIZE
+   struct p_text_poke_array *p_text_poke_array;
+#else
    struct text_poke_loc **p_tp_vec;
    int *p_tp_vec_nr;
+#endif
 #if defined(CONFIG_DYNAMIC_DEBUG)
    struct list_head *p_ddebug_tables;
    struct mutex *p_ddebug_lock;

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -110,6 +110,8 @@ static inline unsigned long get_random_long(void) {
 #include <linux/sched/task_stack.h>
 #endif
 
+#include "modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.h"
+
 /*
  * Define kmem_cache_create() flags:
  *  - LKRG has used to leverage SLAB_HWCACHE_ALIGN but memory overhead
@@ -237,11 +239,13 @@ typedef struct _p_lkrg_global_symbols_structure {
 #ifdef CONFIG_TRACEPOINTS
    struct mutex *p_tracepoints_mutex;
 #endif
+#ifdef P_LKRG_CI_ARCH_JUMP_LABEL_TRANSFORM_APPLY_H
 #ifdef TEXT_POKE_MAX_OPCODE_SIZE
    struct p_text_poke_array *p_text_poke_array;
 #else
-   struct text_poke_loc **p_tp_vec;
+   p_text_poke_loc *p_tp_vec;
    int *p_tp_vec_nr;
+#endif
 #endif
 #if defined(CONFIG_DYNAMIC_DEBUG)
    struct list_head *p_ddebug_tables;


### PR DESCRIPTION
### Description
This fixes issues identified in our CI setup when building for and loading into 6.16-rc kernels. Currently 3 separate issues were identified and are (attempted to be) fixed, as described in #396.

### How Has This Been Tested?
In my development VM with an older kernel, and also via our CI jobs (let's see what they say now).