### PR TITLE
Never reset "off", check cred pointers even during seccomp sync

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1092,13 +1092,6 @@ notrace void p_set_ed_process_override_off(struct p_ed_process *p_source) {
    p_source->p_ed_task.p_off = p_off ^ p_global_off_cookie;
 }
 
-notrace void p_reset_ed_flags(struct p_ed_process *p_source) {
-
-   p_source->p_ed_task.p_off = p_global_cnt_cookie ^ p_global_off_cookie;
-   p_source->p_ed_task.p_off_count = 0;
-
-}
-
 static int p_insert_ed_task(struct p_ed_process *p_source) {
 
    int ret;

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1043,11 +1043,11 @@ notrace void p_set_ed_process_on(struct p_ed_process *p_source) {
 
       p_source->p_ed_task.p_off = p_off ^ p_global_off_cookie; // Encode
       p_source->p_ed_task.p_off_count = 0;
-
-      p_cmp_cred_ptr(p_source, true);
 #if defined(CONFIG_SECCOMP)
    }
 #endif
+
+   p_cmp_cred_ptr(p_source, true);
 }
 
 notrace void p_set_ed_process_off(struct p_ed_process *p_source) {
@@ -1063,11 +1063,11 @@ notrace void p_set_ed_process_off(struct p_ed_process *p_source) {
       p_off += p_global_cnt_cookie;               // Normalize
 
       p_source->p_ed_task.p_off = p_off ^ p_global_off_cookie;
-
-      p_cmp_cred_ptr(p_source, false);
 #if defined(CONFIG_SECCOMP)
    }
 #endif
+
+   p_cmp_cred_ptr(p_source, false);
 }
 
 notrace void p_set_ed_process_override_on(struct p_ed_process *p_source) {

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -398,7 +398,6 @@ void p_ed_validate_off_flag_wrap(struct p_ed_process *p_source);
 /* For override */
 void p_set_ed_process_override_on(struct p_ed_process *p_source);
 void p_set_ed_process_override_off(struct p_ed_process *p_source);
-void p_reset_ed_flags(struct p_ed_process *p_source);
 #if P_OVL_OVERRIDE_SYNC_MODE
 /* For OverlayFS */
 int p_verify_ovl_override_sync(struct p_ed_process *p_source);

--- a/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
+++ b/src/modules/exploit_detection/syscalls/exec/p_security_bprm_committed_creds/p_security_bprm_committed_creds.c
@@ -36,7 +36,7 @@ static LKRG_DEBUG_TRACE int p_security_bprm_committed_creds_ret(struct kretprobe
 #ifdef P_LKRG_TASK_OFF_DEBUG
       p_debug_off_flag_reset(p_tmp, 40);
 #endif
-      p_reset_ed_flags(p_tmp);
+      p_set_ed_process_on(p_tmp);
       ed_task_unlock(p_tmp);
    }
 


### PR DESCRIPTION
### Description
1. Resetting `off` was wrong during seccomp sync. Let's never do that. Fixes #388.
2. The `off` override during seccomp sync isn't the same as creds override, and no creds override is expected where we call the non-override form of `p_set_ed_process_on` / `p_set_ed_process_off`. So let's perform the creds pointer checks added in #394 even during seccomp sync.

### How Has This Been Tested?
The first change was tested for a while in my development VM. Both changes together are tested in our CI setup. I'll test these some more before merging.