### PR TITLE
pINT: No longer store/validate override creds

### DIFF
--- a/.github/workflows/mkosi-boot.yml
+++ b/.github/workflows/mkosi-boot.yml
@@ -12,6 +12,10 @@ jobs:
                     - bionic
                     - focal
                     - jammy
+                    - noble
+                    - oracular
+                    - plucky
+                    - questing
         steps:
             - uses: actions/checkout@v3
             - run: sudo apt-get update

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ The following major changes have been made since 0.9.9:
     limiting detection of cred pointer overwrite attacks on those kernels
  *) To compensate for the above and as an enhancement on older kernels, check
     for cred pointer overwrites in certain other places where we did not before
+ *) Do not track those credentials that we currently do not validate anyway
  *) Switch many hooks from kretprobes to simple kprobes for greater reliability
     and improved performance
  *) Overhaul locking of per-task shadow data, using finer-grain locks

--- a/README
+++ b/README
@@ -12,7 +12,7 @@ RHEL7's (and its many clones/revisions) to latest mainline and distros kernels.
 LKRG 0.9.9 should work correctly with Linux kernels up to 6.12.y, and mostly
 with 6.13.y.  The current git revision has been updated to also work correctly
 with 6.13+ and our CI setup has tested it with kernels up to Fedora's build of
-6.16.0-0.rc1.250613g27605c8c0f69.21.fc43.x86_64.
+6.17.0-0.rc0.250808g37816488247d.14.fc43.x86_64.
 
 LKRG currently supports the x86-64, 32-bit x86, AArch64 (ARM64), and 32-bit ARM
 CPU architectures.

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1332,18 +1332,39 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    get_cred(p_current_real_cred);
 
    /*
+    * Valid cases here:
+    * 1. No credentials change nor override, so both data and pointers match.
+    * 2. Untracked commit_creds(), but no change in tracked credentials, so
+    *    data matches, but pointers differ from saved, yet match each other.
+    * 3. Untracked override_creds() on 6.13+, so real_cred data and pointer
+    *    match what we saved, but cred differs from real_cred.
+    *
+    * Invalid cases here:
+    * 1. Untracked commit_creds() that changes our tracked credentials should
+    *    not exist - we're supposed to track all callers of such.
+    * 2. Untracked override_creds() on pre-6.13 should not exist - we track
+    *    override_creds() itself.
+    * 3. Tracked commit_creds() that's still in progress should set "off" for
+    *    the task, which we check for above, so would not reach here.
+    * 4. Tracked maybe-nested override_creds() on pre-6.13 should set "off" for
+    *    the task until a final/outer revert_creds(), so we would not reach
+    *    here with override still in effect.
+    */
+
+   /*
     * Pre-check for *cred pointer corruption and report it if the credentials
     * also differ, but do not report those credentials differences just yet.
-    * This may be weird, but it was preserved over code refactorings for now so
-    * that no unintentional functional changes were made in those.  We may
-    * reconsider it separately.
+    * This is needed because we do not hook some callers of commit_creds(),
+    * such as by LSMs, where only creds that we currently do not track may
+    * change (so we'd only detect the pointer change, which would be a false
+    * positive).
     *
     * We no longer hook override_creds() on Linux 6.13+, so we infer that an
-    * override is in effect through only the cred pointer being different, but
-    * real_cred staying unchanged.  If both have changed, commit_creds() may
-    * have been used.  Here we assume that uses of override_creds*() are
-    * legitimate, but uses of commit_creds() are not (we set our "off" flag on
-    * the legitimate ones, so would not reach this function in those cases).
+    * override is in effect through only the cred pointer being different,
+    * but real_cred staying unchanged.  If both have changed, commit_creds()
+    * may have been used.  Here we assume that uses of override_creds*() are
+    * legitimate on 6.13+, but uses of commit_creds() are not (we would not
+    * reach these final checks on legitimate uses).
     */
    if (unlikely(p_orig->p_ed_task.p_cred_ptr != p_current_cred)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1371,6 +1371,16 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
 #endif
          P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_cred, "cred")
    }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
+   else if (unlikely(p_current_real_cred != p_current_cred)) {
+      /*
+       * Unexpected override_creds() or equivalent hack is invalid on its own,
+       * but let's also report on any specific differences in the credentials.
+       */
+      p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_cred, p_current);
+      P_CMP_PTR(p_current_real_cred, p_current_cred, "cred or real_cred")
+   }
+#endif
 
    /* Namespaces */
    if (p_orig->p_ed_task.p_nsproxy && (p_current == current || spin_trylock(&p_current->alloc_lock))) {

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -527,7 +527,6 @@ notrace void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    get_task_struct(p_task);
    /* Track process's metadata */
    p_source->p_ed_task.p_pid                      = p_task->pid;
-   p_source->p_ed_task.p_cred_ptr                 = rcu_dereference(p_task->cred);
    p_source->p_ed_task.p_real_cred_ptr            = rcu_dereference(p_task->real_cred);
    if (p_stack)
       p_source->p_ed_task.p_stack                 = p_task->stack;
@@ -561,7 +560,6 @@ notrace void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    } else
       p_source->p_ed_task.p_nsproxy = NULL;
    /* Creds */
-   p_dump_creds(&p_source->p_ed_task.p_cred, p_source->p_ed_task.p_cred_ptr);
    p_dump_creds(&p_source->p_ed_task.p_real_cred, p_source->p_ed_task.p_real_cred_ptr);
 #if defined(CONFIG_SECCOMP)
    /* Seccomp */
@@ -1352,45 +1350,32 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
     */
 
    /*
-    * Pre-check for *cred pointer corruption and report it if the credentials
-    * also differ, but do not report those credentials differences just yet.
-    * This is needed because we do not hook some callers of commit_creds(),
-    * such as by LSMs, where only creds that we currently do not track may
-    * change (so we'd only detect the pointer change, which would be a false
-    * positive).
-    *
-    * We no longer hook override_creds() on Linux 6.13+, so we infer that an
-    * override is in effect through only the cred pointer being different,
-    * but real_cred staying unchanged.  If both have changed, commit_creds()
-    * may have been used.  Here we assume that uses of override_creds*() are
-    * legitimate on 6.13+, but uses of commit_creds() are not (we would not
-    * reach these final checks on legitimate uses).
+    * Check the actual credentials and report any differences
     */
-   if (unlikely(p_orig->p_ed_task.p_cred_ptr != p_current_cred)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
-      && p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred
-#endif
-      ) {
-      if (p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x0)) {
-         P_CMP_PTR(p_orig->p_ed_task.p_cred_ptr, p_current_cred, "cred")
-      }
-   }
+   if (unlikely(p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 1))) {
+      p_ret++;
 
-   if (unlikely(p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred)) {
-      if (p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x0)) {
-         P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_real_cred, "real_cred")
-      }
-   }
+      /*
+       * Now also check the pointers.  We don't do it when credentials match
+       * because we do not hook some callers of commit_creds(), such as by
+       * LSMs, where only creds that we currently do not track may change (so
+       * we'd only detect the pointer change, which would be a false positive).
+       */
+      P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_real_cred, "real_cred")
 
-   /*
-    * Now (re-)check the credentials and report any differences.
-    */
+      /*
+       * We no longer hook override_creds() on Linux 6.13+, so we infer that an
+       * override is in effect through only the cred pointer being different,
+       * but real_cred staying unchanged.  If both have changed, commit_creds()
+       * may have been used.  Here we assume that uses of override_creds*() are
+       * legitimate on 6.13+, but uses of commit_creds() are not (we would not
+       * reach these final checks on legitimate uses).
+       */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
-   if (likely(p_orig->p_ed_task.p_cred_ptr == p_current_cred) ||
-      unlikely(p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred))
+      if (unlikely(p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred))
 #endif
-      p_ret += p_cmp_creds(&p_orig->p_ed_task.p_cred, p_current_cred, p_current, 0x1);
-   p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 0x1);
+         P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_cred, "cred")
+   }
 
    /* Namespaces */
    if (p_orig->p_ed_task.p_nsproxy && (p_current == current || spin_trylock(&p_current->alloc_lock))) {
@@ -1473,11 +1458,10 @@ static inline void p_cmp_cred_ptr(struct p_ed_process *edp, bool full_check) {
    int p_ret = 0;
 
    if (full_check) {
-      P_CMP_PTR(edp->p_ed_task.p_cred_ptr, p_current_cred, "cred")
       P_CMP_PTR(edp->p_ed_task.p_real_cred_ptr, p_current_real_cred, "real_cred")
-   }
-   if (likely(!p_ret))
-      P_CMP_PTR(p_current_real_cred, p_current_cred, "cred")
+      P_CMP_PTR(edp->p_ed_task.p_real_cred_ptr, p_current_cred, "cred")
+   } else
+      P_CMP_PTR(p_current_real_cred, p_current_cred, "cred or real_cred")
 
    if (unlikely(p_ret))
       p_ed_kill_task(edp);

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1236,18 +1236,16 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
    return p_ret;
 }
 
-static int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred, struct task_struct *p_current, char p_opt) {
+static int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred, struct task_struct *p_current) {
 
    int p_ret = 0;
 
 #define P_CMP_CRED(eq, get, cred) \
    if (unlikely(!eq(p_orig->cred, p_current_cred->cred))) { \
-      if (p_opt) { \
-         p_print_log(P_LOG_ALERT, \
-            "DETECT: Task: " #cred " corruption (expected %u vs. actual %u) for pid %u, name %s", \
-            get(&p_orig->cred), get(&p_current_cred->cred), \
-            task_pid_nr(p_current), p_current->comm); \
-      } \
+      p_print_log(P_LOG_ALERT, \
+         "DETECT: Task: " #cred " corruption (expected %u vs. actual %u) for pid %u, name %s", \
+         get(&p_orig->cred), get(&p_current_cred->cred), \
+         task_pid_nr(p_current), p_current->comm); \
       p_ret++; \
    }
 
@@ -1265,16 +1263,14 @@ static int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred,
 
 #define P_CMP_PTR(orig, curr, name) \
    if (unlikely(orig != curr)) { \
-      if (p_opt) { \
-         if (P_CTRL(p_log_level) >= P_LOG_WATCH) \
-            p_print_log(P_LOG_ALERT, \
-               "DETECT: Task: " name " pointer corruption (expected 0x%lx vs. actual 0x%lx) for pid %u, name %s", \
-               (unsigned long)orig, (unsigned long)curr, task_pid_nr(p_current), p_current->comm); \
-         else \
-            p_print_log(P_LOG_ALERT, \
-               "DETECT: Task: " name " pointer corruption for pid %u, name %s", \
-               task_pid_nr(p_current), p_current->comm); \
-      } \
+      if (P_CTRL(p_log_level) >= P_LOG_WATCH) \
+         p_print_log(P_LOG_ALERT, \
+            "DETECT: Task: " name " pointer corruption (expected 0x%lx vs. actual 0x%lx) for pid %u, name %s", \
+            (unsigned long)orig, (unsigned long)curr, task_pid_nr(p_current), p_current->comm); \
+      else \
+         p_print_log(P_LOG_ALERT, \
+            "DETECT: Task: " name " pointer corruption for pid %u, name %s", \
+            task_pid_nr(p_current), p_current->comm); \
       p_ret++; \
    }
 
@@ -1288,7 +1284,6 @@ static int p_cmp_creds(struct p_cred *p_orig, const struct cred *p_current_cred,
 static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
 
    struct task_struct *p_current = p_orig->p_ed_task.p_task;
-   const char p_opt = 1; /* for uses of the P_CMP_PTR() macro */
    int p_ret = 0, p_killed = 0;
    register long p_off = p_orig->p_ed_task.p_off ^ p_global_off_cookie;
    const struct cred *p_current_cred = NULL;
@@ -1352,7 +1347,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    /*
     * Check the actual credentials and report any differences
     */
-   if (unlikely(p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current, 1))) {
+   if (unlikely(p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_real_cred, p_current))) {
       p_ret++;
 
       /*
@@ -1454,7 +1449,6 @@ static inline void p_cmp_cred_ptr(struct p_ed_process *edp, bool full_check) {
    struct task_struct *p_current = edp->p_ed_task.p_task;
    const struct cred *p_current_cred = p_current->cred;
    const struct cred *p_current_real_cred = p_current->real_cred;
-   const char p_opt = 1; /* for uses of the P_CMP_PTR() macro */
    int p_ret = 0;
 
    if (full_check) {

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -280,9 +280,7 @@ struct p_ed_process_task {
    struct task_struct *p_task;
    pid_t p_pid;
    char p_comm[TASK_COMM_LEN+1];
-   const struct cred *p_cred_ptr;
    const struct cred *p_real_cred_ptr;
-   struct p_cred p_cred;
    struct p_cred p_real_cred;
 #if defined(CONFIG_SECCOMP)
    struct p_seccomp p_sec;

--- a/src/modules/self-defense/hiding/p_hiding.h
+++ b/src/modules/self-defense/hiding/p_hiding.h
@@ -68,6 +68,14 @@ do {                                                                       \
    list_add_rcu(&x->list, y);                                              \
 } while(0)
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,17,0)
+/* Moved from include/linux/module.h to kernel/module/internal.h */
+struct module_use {
+   struct list_head source_list;
+   struct list_head target_list;
+   struct module *source, *target;
+};
+#endif
 
 #define P_UNHIDE_FROM_KOBJ(p_mod,p_kset,p_ktype)                           \
 do {                                                                       \


### PR DESCRIPTION
### Description
This fixes #374 and simplifies things at the same time. It also adds more Ubuntu CI jobs, and fixes #406.

### How Has This Been Tested?
In our CI setup and in my dev VM. I haven't yet tested that credentials overwrite detection still works after these changes - I will before merging this.