### PR TITLE
Intel CET IBT support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ The following major changes have been made since 0.9.9:
  *) To compensate for the above and as an enhancement on older kernels, check
     for cred pointer overwrites in certain other places where we did not before
  *) Do not track those credentials that we currently do not validate anyway
+ *) Support (or rather be compatible with the kernel's use of) Intel CET IBT
  *) Switch many hooks from kretprobes to simple kprobes for greater reliability
     and improved performance
  *) Overhaul locking of per-task shadow data, using finer-grain locks

--- a/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
+++ b/src/modules/database/FTRACE/p_ftrace_modify_all_code/p_ftrace_modify_all_code.c
@@ -68,10 +68,10 @@ static notrace int p_ftrace_modify_all_code_entry(struct kretprobe_instance *p_r
       p_ftrace_tmp_text++;
    }
 
-   for (p_iter = P_SYM(p_ftrace_rec_iter_start)(); p_iter; p_iter = P_SYM(p_ftrace_rec_iter_next)(p_iter)) {
-      p_rec = P_SYM(p_ftrace_rec_iter_record)(p_iter);
+   for (p_iter = P_SYM_CALL(p_ftrace_rec_iter_start); p_iter; p_iter = P_SYM_CALL(p_ftrace_rec_iter_next, p_iter)) {
+      p_rec = P_SYM_CALL(p_ftrace_rec_iter_record, p_iter);
 
-      if (P_SYM(p_core_kernel_text)(p_rec->ip)) {
+      if (P_SYM_CALL(p_core_kernel_text, p_rec->ip)) {
 
          p_ftrace_tmp_text++;
 

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform/p_arch_jump_label_transform.c
@@ -59,7 +59,7 @@ static notrace int p_arch_jump_label_transform_entry(struct kretprobe_instance *
                p_jump_entry_target(p_tmp),
                (unsigned long)p_jump_entry_key(p_tmp));
 
-   if (P_SYM(p_core_kernel_text)(p_addr)) {
+   if (P_SYM_CALL(p_core_kernel_text, p_addr)) {
       /*
        * OK, *_JUMP_LABEL tries to modify kernel core .text section
        */

--- a/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
+++ b/src/modules/database/JUMP_LABEL/p_arch_jump_label_transform_apply/p_arch_jump_label_transform_apply.c
@@ -80,7 +80,7 @@ static notrace int p_arch_jump_label_transform_apply_entry(struct kretprobe_inst
 #else
                   (unsigned long)p_tmp->addr;
 #endif
-      if (P_SYM(p_core_kernel_text)(p_addr)) {
+      if (P_SYM_CALL(p_core_kernel_text, p_addr)) {
          p_text = true;
       } else if ((p_module = LKRG_P_MODULE_TEXT_ADDRESS(p_addr))) {
          for (p_mod_id = 0; p_mod_id < p_db.p_module_list_nr; p_mod_id++) {

--- a/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
+++ b/src/modules/database/TRACEPOINT/p_arch_static_call_transform/p_arch_static_call_transform.c
@@ -61,7 +61,7 @@ static notrace int p_arch_static_call_transform_entry(struct kretprobe_instance 
                   "[TRACEPOINT] New modification: code[0x%lx]!",
                   (unsigned long)p_tramp);
 
-      if (P_SYM(p_core_kernel_text)(p_tramp)) {
+      if (P_SYM_CALL(p_core_kernel_text, p_tramp)) {
 
          p_tracepoint_tmp_text++;
 
@@ -95,7 +95,7 @@ static notrace int p_arch_static_call_transform_entry(struct kretprobe_instance 
                   "[TRACEPOINT] New modification: code[0x%lx]!",
                   (unsigned long)p_site);
 
-      if (P_SYM(p_core_kernel_text)(p_site)) {
+      if (P_SYM_CALL(p_core_kernel_text, p_site)) {
 
          p_tracepoint_tmp_text++;
 

--- a/src/modules/database/p_database.c
+++ b/src/modules/database/p_database.c
@@ -23,8 +23,8 @@ int hash_from_ex_table(void) {
 
    unsigned long p_tmp = 0;
 
-   p_db.kernel_ex_table.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("__start___ex_table");
-   p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("__stop___ex_table");
+   p_db.kernel_ex_table.p_addr = (unsigned long *)P_SYM_CALL(p_kallsyms_lookup_name, "__start___ex_table");
+   p_tmp = (unsigned long)P_SYM_CALL(p_kallsyms_lookup_name, "__stop___ex_table");
 
    if (!p_db.kernel_ex_table.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_ex_table.p_addr) {
       return P_LKRG_GENERAL_ERROR;
@@ -47,8 +47,8 @@ int hash_from_kernel_stext(void) {
 
    unsigned long p_tmp = 0;
 
-   p_db.kernel_stext.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("_stext");
-   p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("_etext");
+   p_db.kernel_stext.p_addr = (unsigned long *)P_SYM_CALL(p_kallsyms_lookup_name, "_stext");
+   p_tmp = (unsigned long)P_SYM_CALL(p_kallsyms_lookup_name, "_etext");
 
    if (!p_db.kernel_stext.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_stext.p_addr) {
       return P_LKRG_GENERAL_ERROR;
@@ -84,8 +84,8 @@ int hash_from_kernel_rodata(void) {
 
    unsigned long p_tmp = 0;
 
-   p_db.kernel_rodata.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("__start_rodata");
-   p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("__end_rodata");
+   p_db.kernel_rodata.p_addr = (unsigned long *)P_SYM_CALL(p_kallsyms_lookup_name, "__start_rodata");
+   p_tmp = (unsigned long)P_SYM_CALL(p_kallsyms_lookup_name, "__end_rodata");
 
    if (!p_db.kernel_rodata.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_rodata.p_addr) {
       return P_LKRG_GENERAL_ERROR;
@@ -117,8 +117,8 @@ int hash_from_iommu_table(void) {
 #ifdef CONFIG_X86
    unsigned long p_tmp = 0;
 
-   p_db.kernel_iommu_table.p_addr = (unsigned long *)P_SYM(p_kallsyms_lookup_name)("__iommu_table");
-   p_tmp = (unsigned long)P_SYM(p_kallsyms_lookup_name)("__iommu_table_end");
+   p_db.kernel_iommu_table.p_addr = (unsigned long *)P_SYM_CALL(p_kallsyms_lookup_name, "__iommu_table");
+   p_tmp = (unsigned long)P_SYM_CALL(p_kallsyms_lookup_name, "__iommu_table_end");
 
    if (!p_db.kernel_iommu_table.p_addr || !p_tmp || p_tmp < (unsigned long)p_db.kernel_iommu_table.p_addr) {
       return P_LKRG_GENERAL_ERROR;
@@ -300,7 +300,7 @@ int p_create_database(void) {
 #endif
 
 #if defined(CONFIG_OPTPROBES)
-   P_SYM(p_wait_for_kprobe_optimizer)();
+   P_SYM_CALL(p_wait_for_kprobe_optimizer);
 #endif
    smp_mb();
 
@@ -335,7 +335,7 @@ int p_create_database(void) {
 
    P_SYM(p_state_init) = 1;
 #if defined(CONFIG_OPTPROBES)
-   P_SYM(p_wait_for_kprobe_optimizer)();
+   P_SYM_CALL(p_wait_for_kprobe_optimizer);
 #endif
    smp_mb();
 

--- a/src/modules/exploit_detection/arch/x86/p_ed_x86_arch.h
+++ b/src/modules/exploit_detection/arch/x86/p_ed_x86_arch.h
@@ -50,7 +50,7 @@
 static inline void p_write_cr4(unsigned long p_arg) {
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
-   P_SYM(p_native_write_cr4)(p_arg);
+   P_SYM_CALL(p_native_write_cr4, p_arg);
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
    write_cr4(p_arg);
 #else

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1849,7 +1849,7 @@ p_ed_enforce_pcfi_do:
 
    //p_not_valid = 0;
       for (i = 0; i < p_trace.nr_entries-p_offset; i++) {
-         if (!P_SYM(p___kernel_text_address)(p_trace.entries[i])) {
+         if (!P_SYM_CALL(p___kernel_text_address, p_trace.entries[i])) {
             if (p_trace.nr_entries-p_offset > 4 && i > 4) {
                memset(p_sym1,0,KSYM_SYMBOL_LEN);
                sprint_symbol_no_offset(p_sym1,p_trace.entries[i-1]);

--- a/src/modules/integrity_timer/p_integrity_timer.c
+++ b/src/modules/integrity_timer/p_integrity_timer.c
@@ -425,7 +425,7 @@ void p_check_integrity(struct work_struct *p_work) {
                            p_module_kobj_nr_tmp, p_module_kobj_tmp, "KOBJ")
                         P_PRINT_ONGOING("Lost")
                      } else {
-                        p_tmp_mod = P_SYM(p_find_module(p_module_kobj_tmp[p_tmp_hash].p_name));
+                        p_tmp_mod = P_SYM_CALL(p_find_module, p_module_kobj_tmp[p_tmp_hash].p_name);
                         if (p_tmp_mod) {
                            P_PRINT_WATCH_FEWER("Lost",
                               p_module_list_nr_tmp, "module list",
@@ -464,7 +464,7 @@ void p_check_integrity(struct work_struct *p_work) {
                         }
                      }
                   } else {
-                     p_tmp_mod = P_SYM(p_find_module(p_module_kobj_tmp[p_tmp_hash].p_name));
+                     p_tmp_mod = P_SYM_CALL(p_find_module, p_module_kobj_tmp[p_tmp_hash].p_name);
                      if (p_tmp_mod) {
                         P_PRINT_WATCH_FEWER("Lost",
                            p_module_list_nr_tmp, "module list",
@@ -526,7 +526,7 @@ void p_check_integrity(struct work_struct *p_work) {
                      if (p_module_list_tmp[p_tmp_hash].p_mod == p_module_activity_ptr) {
                         P_PRINT_ONGOING("Lost")
                      } else {
-                        p_tmp_mod = P_SYM(p_find_module(p_module_list_tmp[p_tmp_hash].p_name));
+                        p_tmp_mod = P_SYM_CALL(p_find_module, p_module_list_tmp[p_tmp_hash].p_name);
                         if (p_tmp_mod) {
                            P_PRINT_LIVE_OR_NOT
                         } else {
@@ -537,7 +537,7 @@ void p_check_integrity(struct work_struct *p_work) {
                         }
                      }
                   } else {
-                     p_tmp_mod = P_SYM(p_find_module(p_module_list_tmp[p_tmp_hash].p_name));
+                     p_tmp_mod = P_SYM_CALL(p_find_module, p_module_list_tmp[p_tmp_hash].p_name);
                      if (p_tmp_mod) {
                         P_PRINT_LIVE_OR_NOT
                      } else {
@@ -624,7 +624,7 @@ void p_check_integrity(struct work_struct *p_work) {
                      if (p_db.p_module_list_array[p_tmp_hash].p_mod == p_module_activity_ptr) {
                         P_PRINT_ONGOING("Lost")
                      } else {
-                        p_tmp_mod = P_SYM(p_find_module(p_db.p_module_list_array[p_tmp_hash].p_name));
+                        p_tmp_mod = P_SYM_CALL(p_find_module, p_db.p_module_list_array[p_tmp_hash].p_name);
                         if (p_tmp_mod) {
                            P_PRINT_LIVE_OR_NOT
                         } else {
@@ -635,7 +635,7 @@ void p_check_integrity(struct work_struct *p_work) {
                         }
                      }
                   } else {
-                     p_tmp_mod = P_SYM(p_find_module(p_db.p_module_list_array[p_tmp_hash].p_name));
+                     p_tmp_mod = P_SYM_CALL(p_find_module, p_db.p_module_list_array[p_tmp_hash].p_name);
                      if (p_tmp_mod) {
                         P_PRINT_LIVE_OR_NOT
                      } else {
@@ -693,13 +693,13 @@ void p_check_integrity(struct work_struct *p_work) {
                      if (p_module_list_tmp[p_tmp_hash].p_mod == p_module_activity_ptr) {
                         P_PRINT_ONGOING("Extra")
                      } else {
-                        p_tmp_mod = P_SYM(p_find_module(p_module_list_tmp[p_tmp_hash].p_name));
+                        p_tmp_mod = P_SYM_CALL(p_find_module, p_module_list_tmp[p_tmp_hash].p_name);
                         if (p_tmp_mod) {
                            P_PRINT_LIVE_OR_NOT
                         }
                      }
                   } else {
-                     p_tmp_mod = P_SYM(p_find_module(p_module_list_tmp[p_tmp_hash].p_name));
+                     p_tmp_mod = P_SYM_CALL(p_find_module, p_module_list_tmp[p_tmp_hash].p_name);
                      if (p_tmp_mod) {
                         P_PRINT_LIVE_OR_NOT
                      }
@@ -775,7 +775,7 @@ void p_check_integrity(struct work_struct *p_work) {
                      if (p_db.p_module_kobj_array[p_tmp_hash].p_mod == p_module_activity_ptr) {
                         P_PRINT_ONGOING("Lost")
                      } else {
-                        p_tmp_mod = P_SYM(p_find_module(p_db.p_module_kobj_array[p_tmp_hash].p_name));
+                        p_tmp_mod = P_SYM_CALL(p_find_module, p_db.p_module_kobj_array[p_tmp_hash].p_name);
                         if (p_tmp_mod) {
                            P_PRINT_LIVE_OR_NOT
                         } else {
@@ -783,7 +783,7 @@ void p_check_integrity(struct work_struct *p_work) {
                         }
                      }
                   } else {
-                     p_tmp_mod = P_SYM(p_find_module(p_db.p_module_kobj_array[p_tmp_hash].p_name));
+                     p_tmp_mod = P_SYM_CALL(p_find_module, p_db.p_module_kobj_array[p_tmp_hash].p_name);
                      if (p_tmp_mod) {
                         P_PRINT_LIVE_OR_NOT
                      } else {
@@ -840,7 +840,7 @@ void p_check_integrity(struct work_struct *p_work) {
                      if (p_module_kobj_tmp[p_tmp_hash].p_mod == p_module_activity_ptr) {
                         P_PRINT_ONGOING("Extra")
                      } else {
-                        p_tmp_mod = P_SYM(p_find_module(p_module_kobj_tmp[p_tmp_hash].p_name));
+                        p_tmp_mod = P_SYM_CALL(p_find_module, p_module_kobj_tmp[p_tmp_hash].p_name);
                         if (p_tmp_mod) {
                            P_PRINT_LIVE_OR_NOT
                         } else {
@@ -851,7 +851,7 @@ void p_check_integrity(struct work_struct *p_work) {
                         }
                      }
                   } else {
-                     p_tmp_mod = P_SYM(p_find_module(p_module_kobj_tmp[p_tmp_hash].p_name));
+                     p_tmp_mod = P_SYM_CALL(p_find_module, p_module_kobj_tmp[p_tmp_hash].p_name);
                      if (p_tmp_mod) {
                         P_PRINT_LIVE_OR_NOT
                      } else {

--- a/src/modules/ksyms/p_resolve_ksym.c
+++ b/src/modules/ksyms/p_resolve_ksym.c
@@ -55,7 +55,7 @@ static int p_find_isra_name(void *p_isra_argg, const char *name,
 
 int p_try_isra_name(struct p_isra_argument *p_isra_arg) {
 
-   return P_SYM(p_kallsyms_on_each_symbol)(p_find_isra_name, p_isra_arg);
+   return P_SYM_CALL(p_kallsyms_on_each_symbol, p_find_isra_name, p_isra_arg);
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0))
@@ -113,7 +113,7 @@ long get_kallsyms_address(void) {
    unregister_kprobe(&p_kprobe);
    P_SYM(p_kallsyms_on_each_symbol) = (int (*)(int (*)(void *, const char *, struct module *,
                                               unsigned long), void *))
-                                       P_SYM(p_kallsyms_lookup_name)("kallsyms_on_each_symbol");
+                                       P_SYM_CALL(p_kallsyms_lookup_name, "kallsyms_on_each_symbol");
 
 #else
 

--- a/src/modules/wrap/p_struct_wrap.h
+++ b/src/modules/wrap/p_struct_wrap.h
@@ -227,7 +227,7 @@ static inline int p_ddebug_remove_module(const char *p_name) {
 
 #else
 
-   return P_SYM(p_ddebug_remove_module)(p_name);
+   return P_SYM_CALL(p_ddebug_remove_module, p_name);
 
 #endif
 
@@ -437,9 +437,9 @@ static inline void p_syscall_set_arg2(struct pt_regs *p_regs, unsigned long p_va
 static inline int p_set_memory_rw(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_rw)(p_addr, p_numpages);
+   return P_SYM_CALL(p_set_memory_rw, p_addr, p_numpages);
 #else
-   return P_SYM(p_change_page_attr_set_clr)(&p_addr, p_numpages,
+   return P_SYM_CALL(p_change_page_attr_set_clr, &p_addr, p_numpages,
                                             __pgprot(_PAGE_RW),
                                             __pgprot(0),
                                             0, 0, NULL);
@@ -449,9 +449,9 @@ static inline int p_set_memory_rw(unsigned long p_addr, int p_numpages) {
 static inline int p_set_memory_ro(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_ro)(p_addr, p_numpages);
+   return P_SYM_CALL(p_set_memory_ro, p_addr, p_numpages);
 #else
-   return P_SYM(p_change_page_attr_set_clr)(&p_addr, p_numpages,
+   return P_SYM_CALL(p_change_page_attr_set_clr, &p_addr, p_numpages,
                                             __pgprot(0),
                                             __pgprot(_PAGE_RW|_PAGE_DIRTY),
                                             0, 0, NULL);
@@ -463,7 +463,7 @@ static inline int p_set_memory_np(unsigned long p_addr, int p_numpages) {
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
    return 0x0;
 #else
-   return P_SYM(p_change_page_attr_set_clr)(&p_addr, p_numpages,
+   return P_SYM_CALL(p_change_page_attr_set_clr, &p_addr, p_numpages,
                                             __pgprot(0),
                                             __pgprot(_PAGE_PRESENT),
                                             0, 0, NULL);
@@ -475,7 +475,7 @@ static inline int p_set_memory_p(unsigned long p_addr, int p_numpages) {
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
    return 0x0;
 #else
-   return P_SYM(p_change_page_attr_set_clr)(&p_addr, p_numpages,
+   return P_SYM_CALL(p_change_page_attr_set_clr, &p_addr, p_numpages,
                                             __pgprot(_PAGE_PRESENT),
                                             __pgprot(0),
                                             0, 0, NULL);
@@ -620,9 +620,9 @@ static inline void p_syscall_set_arg2(struct pt_regs *p_regs, unsigned long p_va
 static inline int p_set_memory_rw(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_rw)(p_addr, p_numpages);
+   return P_SYM_CALL(p_set_memory_rw, p_addr, p_numpages);
 #else
-   return P_SYM(p_change_memory_common)(p_addr, p_numpages,
+   return P_SYM_CALL(p_change_memory_common, p_addr, p_numpages,
                                         __pgprot(0),
                                         __pgprot(L_PTE_RDONLY));
 #endif
@@ -631,9 +631,9 @@ static inline int p_set_memory_rw(unsigned long p_addr, int p_numpages) {
 static inline int p_set_memory_ro(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_ro)(p_addr, p_numpages);
+   return P_SYM_CALL(p_set_memory_ro, p_addr, p_numpages);
 #else
-   return P_SYM(p_change_memory_common)(p_addr, p_numpages,
+   return P_SYM_CALL(p_change_memory_common, p_addr, p_numpages,
                                         __pgprot(L_PTE_RDONLY),
                                         __pgprot(0));
 #endif
@@ -755,9 +755,9 @@ static inline void p_syscall_set_arg2(struct pt_regs *p_regs, unsigned long p_va
 static inline int p_set_memory_rw(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_rw)(p_addr, p_numpages);
+   return P_SYM_CALL(p_set_memory_rw, p_addr, p_numpages);
 #else
-   return P_SYM(p_change_memory_common)(p_addr, p_numpages,
+   return P_SYM_CALL(p_change_memory_common, p_addr, p_numpages,
                                         __pgprot(PTE_WRITE),
                                         __pgprot(PTE_RDONLY));
 #endif
@@ -766,9 +766,9 @@ static inline int p_set_memory_rw(unsigned long p_addr, int p_numpages) {
 static inline int p_set_memory_ro(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_ro)(p_addr, p_numpages);
+   return P_SYM_CALL(p_set_memory_ro, p_addr, p_numpages);
 #else
-   return P_SYM(p_change_memory_common)(p_addr, p_numpages,
+   return P_SYM_CALL(p_change_memory_common, p_addr, p_numpages,
                                         __pgprot(PTE_RDONLY),
                                         __pgprot(PTE_WRITE));
 #endif
@@ -777,9 +777,9 @@ static inline int p_set_memory_ro(unsigned long p_addr, int p_numpages) {
 static inline int p_set_memory_np(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_valid)(p_addr, p_numpages, 0);
+   return P_SYM_CALL(p_set_memory_valid, p_addr, p_numpages, 0);
 #else
-   return P_SYM(p_change_memory_common)(p_addr, p_numpages,
+   return P_SYM_CALL(p_change_memory_common, p_addr, p_numpages,
                                         __pgprot(0),
                                         __pgprot(PTE_VALID));
 #endif
@@ -788,9 +788,9 @@ static inline int p_set_memory_np(unsigned long p_addr, int p_numpages) {
 static inline int p_set_memory_p(unsigned long p_addr, int p_numpages) {
 
 #if defined(P_KERNEL_AGGRESSIVE_INLINING)
-   return P_SYM(p_set_memory_valid)(p_addr, p_numpages, 1);
+   return P_SYM_CALL(p_set_memory_valid, p_addr, p_numpages, 1);
 #else
-   return P_SYM(p_change_memory_common)(p_addr, p_numpages,
+   return P_SYM_CALL(p_change_memory_common, p_addr, p_numpages,
                                         __pgprot(PTE_VALID),
                                         __pgprot(0));
 #endif


### PR DESCRIPTION
Fixes #413

### Description
Initial hack to workaround Intel CET IBT.

### How Has This Been Tested?
In our CI and in an Arch Linux VM, and also by forcing this code to be compiled in and/or running on other x86_64 systems (even without IBT support in the kernel). We do not currently know whether it actually solves the problem, but it should.

After proper testing, next steps may be making it more reliable (not depending on compiler specifics so much, as mentioned in the lengthy source code comment) and/or implementing a similar trick for ARM BTI.