### PR TITLE
pINT: Allow SECCOMP_MODE_DEAD

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1423,7 +1423,8 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
          p_ret++;
       }
 
-      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_current->seccomp.mode)) {
+      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_current->seccomp.mode) &&
+          likely(p_current->seccomp.mode != 3 /* SECCOMP_MODE_DEAD */)) {
          if (p_current->seccomp.mode < 0 || p_current->seccomp.mode > 2
              || p_orig->p_ed_task.p_sec.sec.mode < 0 || p_orig->p_ed_task.p_sec.sec.mode > 2) {
             p_print_log(P_LOG_ALERT, "DETECT: Task: seccomp mode corruption (expected %u vs. actual %u) for pid %u, name %s",

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1288,6 +1288,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    register long p_off = p_orig->p_ed_task.p_off ^ p_global_off_cookie;
    const struct cred *p_current_cred = NULL;
    const struct cred *p_current_real_cred = NULL;
+   int p_seccomp_mode;
 
    if (p_off - p_global_cnt_cookie) {
       if (p_kill)
@@ -1423,16 +1424,22 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
          p_ret++;
       }
 
-      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_current->seccomp.mode) &&
-          likely(p_current->seccomp.mode != 3 /* SECCOMP_MODE_DEAD */)) {
-         if (p_current->seccomp.mode < 0 || p_current->seccomp.mode > 2
+      /*
+       * Use READ_ONCE because SECCOMP_MODE_DEAD may be set async to our checks
+       * when we are validating other than the current task, yet we need our
+       * checks to be internally consistent.
+       */
+      p_seccomp_mode = READ_ONCE(p_current->seccomp.mode);
+      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_seccomp_mode) &&
+          p_seccomp_mode != 3 /* SECCOMP_MODE_DEAD */) {
+         if (p_seccomp_mode < 0 || p_seccomp_mode > 2
              || p_orig->p_ed_task.p_sec.sec.mode < 0 || p_orig->p_ed_task.p_sec.sec.mode > 2) {
             p_print_log(P_LOG_ALERT, "DETECT: Task: seccomp mode corruption (expected %u vs. actual %u) for pid %u, name %s",
-               p_orig->p_ed_task.p_sec.sec.mode, p_current->seccomp.mode, task_pid_nr(p_current), p_current->comm);
+               p_orig->p_ed_task.p_sec.sec.mode, p_seccomp_mode, task_pid_nr(p_current), p_current->comm);
          } else {
             static const char * const p_sec_strings[] = {"SECCOMP_MODE_DISABLED", "SECCOMP_MODE_STRICT", "SECCOMP_MODE_FILTER"};
             p_print_log(P_LOG_ALERT, "DETECT: Task: seccomp mode corruption (expected %s vs. actual %s) for pid %u, name %s",
-               p_sec_strings[p_orig->p_ed_task.p_sec.sec.mode], p_sec_strings[p_current->seccomp.mode],
+               p_sec_strings[p_orig->p_ed_task.p_sec.sec.mode], p_sec_strings[p_seccomp_mode],
                task_pid_nr(p_current), p_current->comm);
          }
          p_ret++;

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1427,11 +1427,20 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
       /*
        * Use READ_ONCE because SECCOMP_MODE_DEAD may be set async to our checks
        * when we are validating other than the current task, yet we need our
-       * checks to be internally consistent.
+       * checks to be internally consistent.  Limit SECCOMP_MODE_DEAD support
+       * to kernels that actually have it, so that this magic value cannot be
+       * used to silently bypass our validation on older kernels.  The kernels
+       * that support it will kill the SECCOMP_MODE_DEAD task on their own.
        */
       p_seccomp_mode = READ_ONCE(p_current->seccomp.mode);
-      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_seccomp_mode) &&
-          p_seccomp_mode != 3 /* SECCOMP_MODE_DEAD */) {
+      if (unlikely(p_orig->p_ed_task.p_sec.sec.mode != p_seccomp_mode)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,10) || \
+    (LINUX_VERSION_CODE < KERNEL_VERSION(5,16,0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,24)) || \
+    (LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,211)) || \
+    (LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,180))
+          && p_seccomp_mode != 3 /* SECCOMP_MODE_DEAD on 5.17+ and backports */
+#endif
+          ) {
          if (p_seccomp_mode < 0 || p_seccomp_mode > 2
              || p_orig->p_ed_task.p_sec.sec.mode < 0 || p_orig->p_ed_task.p_sec.sec.mode > 2) {
             p_print_log(P_LOG_ALERT, "DETECT: Task: seccomp mode corruption (expected %u vs. actual %u) for pid %u, name %s",


### PR DESCRIPTION
Fixes #408

### Description

This allows a task's current seccomp mode to be `SECCOMP_MODE_DEAD`, which happens when the task is exiting.

It weakens our detection slightly as an exploit could set this mode and go undetected by LKRG, but doing so would instead trigger the kernel itself to detect this soon and do:

```c
        /* Surviving SECCOMP_RET_KILL_* must be proactively impossible. */
        case SECCOMP_MODE_DEAD:
                WARN_ON_ONCE(1);
                do_exit(SIGKILL);
                return -1;
```

So an exploit doing this doesn't appear to achieve anything - not a bypass, but task killed.

### How Has This Been Tested?

On my dev VM and in our CI setup. Reproducing the original issue took a couple of months, so I'm not waiting for that, and we do not have a test case developed specifically to trigger this quickly.