### PR TITLE
Drop section .p_lkrg_read_only

### DIFF
--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -48,7 +48,7 @@ unsigned int p_attr_init = 0;
 
 DEFINE_MUTEX(p_ro_page_mutex);
 
-p_ro_page p_ro __p_lkrg_read_only = {
+p_ro_page p_ro = {
 
 #if !defined(CONFIG_ARM) && (!defined(P_KERNEL_AGGRESSIVE_INLINING) && defined(CONFIG_X86))
    .p_marker_np1 = P_LKRG_MARKER1,

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -135,9 +135,6 @@ static inline unsigned long get_random_long(void) {
  */
 //#define P_KERNEL_AGGRESSIVE_INLINING 1
 
-//#define p_lkrg_read_only __attribute__((__section__(".data..p_lkrg_read_only"),aligned(PAGE_SIZE)))
-#define __p_lkrg_read_only __attribute__((__section__(".p_lkrg_read_only")))
-
 #if defined(CONFIG_X86_64) || defined(CONFIG_ARM64)
  #define P_LKRG_MARKER1 0x3369705f6d616441
  #define P_LKRG_MARKER2 0xdeadbabedeadbabe


### PR DESCRIPTION
### Description

If we don't explicitly specify section alignment, then perhaps an existing section is page-aligned or not just as well, so our page-alignment of a symbol within that section will work or fail just as well.

Fixes #158

### How Has This Been Tested?

LKRG built and loaded cleanly in my dev VM. I've also confirmed that our sysctl settings _are_ read-only in such build, by temporarily removing a pair of calls like this:

```diff
+++ b/src/modules/comm_channel/p_comm_channel.c
@@ -477,14 +477,14 @@ static int p_sysctl_interval(P_STRUCT_CTL_TABLE *p_table, int p_write,
    unsigned int p_tmp;
 
    p_tmp = P_CTRL(p_interval);
-   p_lkrg_open_rw();
+//   p_lkrg_open_rw();
    if ( (p_ret = proc_dointvec_minmax(p_table, p_write, p_buffer, p_len, p_pos)) == 0 && p_write) {
       if (P_CTRL(p_interval) != p_tmp) {
          p_print_log(P_LOG_STATE, "Changing 'interval' from %d to %d", p_tmp, P_CTRL(p_interval));
          p_offload_work(0); // run integrity check!
       }
    }
-   p_lkrg_close_rw();
+//   p_lkrg_close_rw();
 
    return p_ret;
 }
```

and trying to update this sysctl. The system Oops'ed with a page fault inside `proc_dointvec_minmax` just as expected.

Testing by our CI jobs is in progress.