### PR TITLE
Support Intel CET IBT also with clang, and support KCFI (clang CFI)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ The following major changes have been made since 0.9.9:
     for cred pointer overwrites in certain other places where we did not before
  *) Do not track those credentials that we currently do not validate anyway
  *) Support (or rather be compatible with the kernel's use of) Intel CET IBT
+    (CONFIG_X86_KERNEL_IBT) and/or KCFI (CONFIG_CFI_CLANG) for now on x86_64
  *) Switch many hooks from kretprobes to simple kprobes for greater reliability
     and improved performance
  *) Overhaul locking of per-task shadow data, using finer-grain locks


### PR DESCRIPTION
Fixes #259

### Description

This extends #415 to also support clang, based on testing by @0xC0ncord in #259.

### How Has This Been Tested?

So far only directly tested in my dev VM and in our CI setup with gcc. I don't test with clang. But the approach is similar to what @0xC0ncord had kindly tested for us (currently running into other and likely unrelated issues with hardened/optimized kernels and clang, so I think this part is ready for a PR).

We may also need to complete and merge #419 to support clang builds.