### PR TITLE
Don't hook anything OverlayFS on 6.13+

### DIFF
--- a/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
+++ b/src/modules/exploit_detection/syscalls/override/overlayfs/p_ovl_override_sync/p_ovl_override_sync.h
@@ -6,9 +6,9 @@
  *    'ovl_create_or_link'.
  *
  * Notes:
- *  - We are maintianing Red-Black tree of pid's for Exploit Detection feature.
- *    When process calls 'ovl_create_or_link', we need to correctly handle
- *    this situation and adjust 'off' flag
+ *  - Some code paths in OverlayFS call override_creds() twice yet later call
+ *    revert_creds() only once.  We need to correctly handle this situation and
+ *    adjust 'off' flag.
  *
  * Caveats:
  *  - Originally, 'ovl_create_or_link' function was hooked.
@@ -26,7 +26,13 @@
 #ifndef P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H
 #define P_LKRG_EXPLOIT_DETECTION_OVL_OVERRIDE_SYNC_H
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+/*
+ * We can't/don't hook override/revert_creds() on 6.13+, so we also don't need
+ * to hook anything OverlayFS on those kernels.
+ */
+#define P_OVL_OVERRIDE_SYNC_MODE 0
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
 /*
  * 6.10 introduces ovl_tmpfile() which we need to cover, but it doesn't use
  * ovl_dentry_is_whiteout(). Probe ovl_dentry_init_reval() instead.

--- a/src/modules/kmod/p_kmod.h
+++ b/src/modules/kmod/p_kmod.h
@@ -59,9 +59,6 @@ typedef struct p_module_kobj_mem {
 extern struct mutex p_module_activity;
 extern struct module *p_module_activity_ptr;
 
-void p_verify_module_live(struct module *p_mod);
-void p_verify_module_going(struct module *p_mod);
-
 int p_kmod_init(void);
 int p_kmod_hash(unsigned int *p_module_list_cnt_arg, p_module_list_mem **p_mlm_tmp,
                 unsigned int *p_module_kobj_cnt_arg, p_module_kobj_mem **p_mkm_tmp, char p_flag);


### PR DESCRIPTION
### Description

We can't/don't hook override/revert_creds() on 6.13+, so we also don't need to hook anything OverlayFS on those kernels.

Fixes #426

### How Has This Been Tested?

In my dev VM (pre-6.13 kernel), in an Arch Linux VM with 6.14+ and a Docker container, and in our CI setup.