### PR TITLE
pINT: Do not misuse get_cred(), get_task_struct(), memory barriers

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -404,7 +404,6 @@ notrace void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    p_print_log(P_LOG_WATCH, "Updating pid %u", p_task->pid);
 
    rcu_read_lock();
-   get_task_struct(p_task);
    /* Track process's metadata */
    p_source->p_ed_task.p_pid                      = p_task->pid;
    p_source->p_ed_task.p_real_cred_ptr            = rcu_dereference(p_task->real_cred);
@@ -454,7 +453,6 @@ notrace void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    p_source->p_ed_task.p_comm[TASK_COMM_LEN] = 0;
    /* Should be last here to propagate potential glitching */
    wmb();
-   put_task_struct(p_task);
    rcu_read_unlock();
 
 }

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -451,10 +451,7 @@ notrace void p_update_ed_process(struct p_ed_process *p_source, char p_stack) {
    /* Name */
    strncpy(p_source->p_ed_task.p_comm, p_task->comm, TASK_COMM_LEN);
    p_source->p_ed_task.p_comm[TASK_COMM_LEN] = 0;
-   /* Should be last here to propagate potential glitching */
-   wmb();
    rcu_read_unlock();
-
 }
 
 #ifdef P_LKRG_TASK_OFF_DEBUG
@@ -1917,8 +1914,6 @@ void p_exploit_detection_exit(void) {
    for (p_fh_it = p_functions_hooks_array; p_fh_it->name != NULL; p_fh_it++) {
       p_fh_it->uninstall();
    }
-
-   mb();
 
    /* Delete cache for ED wq validation */
    p_ed_wq_valid_cache_delete();

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -303,9 +303,6 @@ static void p_ed_wq_valid_cache_delete(void) {
 
 static notrace void p_dump_creds(struct p_cred *p_where, const struct cred *p_from) {
 
-   /* Get reference to cred */
-   get_cred(p_from);
-
    /* Track process's IDs */
    p_set_uid(&p_where->uid, p_get_uid(&p_from->uid));
    p_set_gid(&p_where->gid, p_get_gid(&p_from->gid));
@@ -317,9 +314,6 @@ static notrace void p_dump_creds(struct p_cred *p_where, const struct cred *p_fr
    p_set_gid(&p_where->fsgid, p_get_gid(&p_from->fsgid));
 
    p_where->user_ns  = p_from->user_ns;
-
-   /* Release reference to cred */
-   put_cred(p_from);
 }
 
 #if defined(CONFIG_SECCOMP)
@@ -1187,12 +1181,9 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    /*
     * Fetch pointers first
     */
+   rcu_read_lock();
    p_current_cred = rcu_dereference(p_current->cred);
-   /* Get reference to cred */
-   get_cred(p_current_cred);
    p_current_real_cred = rcu_dereference(p_current->real_cred);
-   /* Get reference to real_cred */
-   get_cred(p_current_real_cred);
 
    /*
     * Valid cases here:
@@ -1331,10 +1322,7 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
    }
 #endif
 
-   /* Release reference to cred */
-   put_cred(p_current_cred);
-   /* Release reference to real_cred */
-   put_cred(p_current_real_cred);
+   rcu_read_unlock();
 
    return p_killed ? -p_ret : p_ret;
 }


### PR DESCRIPTION
Fixes #430

### Description

1. Drop all uses of `get_cred` / `put_cred`.
2. Add `rcu_read_lock` / `rcu_read_unlock` to `p_cmp_tasks`, even though the callers either already have those (for other reasons) or are for the current task.
3. Drop the only remaining use of `get_task_struct`.
4. Drop two memory barriers.

### How Has This Been Tested?

Light testing in my dev VM, and by our CI.

The first commit also got ~3 hours of stress-testing on the system where I previously saw #430 (not triggering it anymore), which now continues to stress-tests all 3 commits.