### PR TITLE
pINT: Skip __queue_work() probe when called from any non-task context

### DIFF
--- a/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
+++ b/src/modules/exploit_detection/syscalls/pCFI/p___queue_work/p___queue_work.c
@@ -26,7 +26,7 @@ static int p_pcfi___queue_work_entry(struct kprobe *p_ri, struct pt_regs *p_regs
 
    p_ed_pcfi_cpu(0);
 
-   if (!in_irq() && p_is_ed_task(current)) {
+   if (in_task() && p_is_ed_task(current)) {
       /* Do not take ED lock */
       if ((p_tmp = ed_task_trylock_current())) {
          p_ed_validate_current(p_tmp);


### PR DESCRIPTION
### Description

Our task integrity checks assume that the current task is in consistent state, which was apparently not guaranteed here.

Amends 863b28d1ad7d74046b321956df76ec47ae4cfb94
Fixes #432

### How Has This Been Tested?

With extra debugging print on Arch Linux with 6.14.3 as described in #432. Also in a CentOS 7.9 VM just to see that there's no apparent breakage. Now waiting for our CI jobs to complete.

I don't know whether this actually fixes #432, but this is currently my only plausible guess as to what caused the symptoms seen there (just once, not reproduced yet).