### PR TITLE
pCFI: Skip unreliable stack pointer checks on 32-bit x86

### DIFF
--- a/.github/workflows/docker-boot.yml
+++ b/.github/workflows/docker-boot.yml
@@ -8,9 +8,9 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-#                    - args: image=i386/ubuntu:bionic
-#                            qemu=qemu-system-i386
-#                      install: qemu-system-x86
+                    - args: image=i386/ubuntu:bionic
+                            qemu=qemu-system-i386
+                      install: qemu-system-x86
 
                     - args: image=arm64v8/ubuntu:jammy
                             platform=linux/arm64

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1791,6 +1791,9 @@ p_ed_enforce_pcfi_out:
 
 int p_ed_pcfi_validate_sp(struct task_struct *p_task, struct p_ed_process *p_orig, unsigned long p_sp) {
 
+#ifdef CONFIG_X86_32
+   return P_LKRG_SUCCESS;
+#else
    unsigned long p_stack = 0;
    unsigned long p_stack_offset;
    int p_not_valid = 0;
@@ -1847,6 +1850,7 @@ int p_ed_pcfi_validate_sp(struct task_struct *p_task, struct p_ed_process *p_ori
    }
 
    return p_not_valid ? P_LKRG_GENERAL_ERROR : P_LKRG_SUCCESS;
+#endif
 }
 
 


### PR DESCRIPTION
### Description

Skip unreliable stack pointer checks on 32-bit x86, re-enable the only CI job to test this.

I briefly tried to come up with a more fine-grained exception, so that the stack pointer checks would sometimes run and sometimes not, but could not arrive at anything reliable yet. This arch may not be worth more of our time now. If it works at all, that's good - the extra testing may occasionally uncover other issues, which would also be relevant on other archs.

### How Has This Been Tested?

In our CI setup only. The changes are such they shouldn't affect any other archs, and we were not testing this arch for years.