### PR TITLE
pINT: Drop a real_cred pointer corruption check on 6.13+

### DIFF
--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1229,10 +1229,11 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
     * each other, which lets us perform additional checks.
     *
     * commit_creds() changes both pointers, override_creds() only the cred
-    * pointer, but nothing valid changes only the real_cred pointer, so that's
-    * what we can detect as a violation on all kernels.  This violation implies
-    * that the two current pointers differ from each other, but not the other
-    * way around.
+    * pointer, but nothing valid changes only the real_cred pointer.
+    * Unfortunately, we cannot reliably detect this as a violation on pre-6.13
+    * kernels because there may have been both an untracked commit_creds()
+    * changing both pointers and an override_creds() changing the cred pointer
+    * potentially in such a way that the old pointer value we saved is reused.
     *
     * On kernels below 6.13, we directly detect pointers differing from each
     * other as a violation, which covers the above case and also unexpected
@@ -1242,18 +1243,13 @@ static int p_cmp_tasks(struct p_ed_process *p_orig, char p_kill) {
     * from each other, a check of the actual subjective credentials wouldn't be
     * redundant with what we performed above, so we perform it as well.
     */
-   if (current == p_current && unlikely(
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
-       p_current_real_cred != p_current_cred
-#else
-       p_orig->p_ed_task.p_real_cred_ptr != p_current_real_cred &&
-       p_orig->p_ed_task.p_real_cred_ptr == p_current_cred
-#endif
-       )) {
+   if (current == p_current && unlikely(p_current_real_cred != p_current_cred)) {
       P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_real_cred, "real_cred")
       p_ret += p_cmp_creds(&p_orig->p_ed_task.p_real_cred, p_current_cred, p_current);
       P_CMP_PTR(p_orig->p_ed_task.p_real_cred_ptr, p_current_cred, "cred")
    }
+#endif
 
    /* Namespaces */
    if (p_orig->p_ed_task.p_nsproxy && (p_current == current || spin_trylock(&p_current->alloc_lock))) {


### PR DESCRIPTION
### Description

Drop a check introduced a few days ago, which did not take address reuse in consideration.

Amends bf3439b513e3531b5ae930c31cc1bd90c4cd4af5
Fixes #432

### How Has This Been Tested?

Not yet tested. I will test a bit before merging, but really no issues are expected because this just removes a violation check in some builds.