### PR TITLE
Conditional disallow unloading of LKRG 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ ccflags-y := ${ccflags-m}
 $(TARGET)-objs += src/modules/print_log/p_lkrg_debug_log.o
 endif
 
+#
+# Allow overriding LKRG_UNLOAD_PROTECT via Make.
+#
+ifneq ($(LKRG_UNLOAD_PROTECT),)
+ccflags-y += -DLKRG_UNLOAD_PROTECT=$(LKRG_UNLOAD_PROTECT)
+endif
+
 obj-m += $(TARGET).o
 $(TARGET)-objs += src/modules/ksyms/p_resolve_ksym.o \
                   src/modules/hashing/p_lkrg_fast_hash.o \

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -18,6 +18,10 @@
 #ifndef P_LKRG_MAIN_H
 #define P_LKRG_MAIN_H
 
+#ifndef LKRG_UNLOAD_PROTECT
+#define LKRG_UNLOAD_PROTECT 1
+#endif
+
 #define LKRG_WITH_HIDE
 #define P_BOOT_DISABLE_LKRG "nolkrg"
 
@@ -559,6 +563,10 @@ static inline int p_lkrg_counter_lock_val_read(p_lkrg_counter_lock *p_arg) {
 
 #if defined(CONFIG_TRIM_UNUSED_KSYMS) && !defined(CONFIG_SECURITY_LKRG)
  #error "LKRG requires CONFIG_TRIM_UNUSED_KSYMS to be disabled if it should be built as a kernel module"
+#endif
+
+#if LKRG_UNLOAD_PROTECT != 0 && LKRG_UNLOAD_PROTECT != 1
+#error "LKRG_UNLOAD_PROTECT must be 0 or 1"
 #endif
 
 #endif


### PR DESCRIPTION
### Description
This adds some code to bump the module refcount to prevent unloading LKRG. Only makes sense with kernel lockdown enabled and a kernel built with 'CONFIG_MODULE_FORCE_UNLOAD=n' .

### How Has This Been Tested?
Module was compiled with changes and behaved as expected during testing.
