### PR TITLE
Use task works to dump ED tasks instead of freezing userspace

### DIFF
--- a/src/modules/exploit_detection/ed_task_tree.c
+++ b/src/modules/exploit_detection/ed_task_tree.c
@@ -266,10 +266,7 @@ struct p_ed_process *alloc_ed_task(struct task_struct *tsk)
 {
 	struct p_ed_process *edp;
 
-	edp = kmem_cache_zalloc(ed_task_cache, GFP_ATOMIC);
-	if (!edp)
-		return NULL;
-
+	edp = kmem_cache_zalloc(ed_task_cache, GFP_KERNEL | __GFP_NOFAIL);
 	raw_spin_lock_init(&edp->lock);
 	edp->kill_task_on_unlock = cookie_kill_task_on_unlock;
 	edp->p_ed_task.p_task = tsk;

--- a/src/modules/exploit_detection/ed_task_tree.c
+++ b/src/modules/exploit_detection/ed_task_tree.c
@@ -266,7 +266,7 @@ struct p_ed_process *alloc_ed_task(struct task_struct *tsk)
 {
 	struct p_ed_process *edp;
 
-	edp = kmem_cache_zalloc(ed_task_cache, GFP_ATOMIC);
+	edp = kmem_cache_zalloc(ed_task_cache, GFP_KERNEL | __GFP_NOFAIL);
 	if (!edp)
 		return NULL;
 

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1000,9 +1000,8 @@ static int p_insert_ed_task(struct p_ed_process *p_source) {
    return ret;
 }
 
-void p_dump_task_f(void *p_arg) {
+void p_dump_task_f(struct task_struct *p_task) {
 
-   struct task_struct *p_task = (struct task_struct *)p_arg;
    struct p_ed_process *p_tmp;
 
    if (unlikely((p_tmp = alloc_ed_task(p_task)) == NULL)) {

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -22,6 +22,8 @@ static unsigned long p_global_off_cookie;
 static unsigned long p_global_cnt_cookie;
 struct kmem_cache *p_ed_wq_valid_cache = NULL;
 static struct kmem_cache *p_ed_pcfi_cache = NULL;
+static atomic_t p_task_work_cnt = ATOMIC_INIT(0);
+static DECLARE_WAIT_QUEUE_HEAD(p_task_work_waitq);
 
 unsigned long p_pcfi_CPU_flags;
 
@@ -1038,29 +1040,136 @@ void p_dump_task_f(void *p_arg) {
    }
 }
 
+static void p_dump_task_work_cb(struct callback_head *head) {
+
+   struct task_struct *p_task = current;
+
+   /*
+    * Clear out our function pointer from the RCU callback head so module exit
+    * knows to not bother trying to cancel a task work for this task.
+    */
+   p_task->rcu.func = NULL;
+
+   /*
+    * When a task exits, exit_task_work() flushes all the queued task workers.
+    * This occurs after PF_EXITING is set for the exiting task. As such, we can
+    * check for PF_EXITING to know if we are getting called after the task has
+    * entered do_exit(), and the check isn't racy. This way, we won't leak
+    * memory allocating an ed struct after our do_exit() kprobe that frees it.
+    */
+   if (!(p_task->flags & PF_EXITING))
+      p_dump_task_f(p_task);
+
+   /*
+    * Decrement the task work counter and wake up the module exit thread if
+    * there are no more task works in flight and it happens to be waiting. The
+    * atomic_dec_and_test() executes a full memory barrier, providing the
+    * necessary ordering before the lockless waitqueue_active() check so that a
+    * wake-up won't be missed (which would make module exit hang forever).
+    */
+   if (atomic_dec_and_test(&p_task_work_cnt) &&
+       waitqueue_active(&p_task_work_waitq))
+      wake_up(&p_task_work_waitq);
+}
+
+static void p_dump_task_work_add(struct task_struct *p_task) {
+
+   /*
+    * Leverage the RCU callback head in task_struct for memory in order to queue
+    * a task work onto this task. This is safe so long as we don't trample over
+    * the RCU callback head while it's in use for RCU freeing the task, which is
+    * accomplished as described by the comment in p_dump_ed_tasks().
+    */
+   p_task->rcu.func = p_dump_task_work_cb;
+
+   /*
+    * Add the task work and trigger it right before the task context switches
+    * back to userspace. If the task is currently running in userspace, then
+    * this will kick the task into the kernel so it will run soon. If the task
+    * is sleeping then the task won't be woken up since there's no need to wake
+    * it up; if it's sleeping then it can't do anything malicious anyway.
+    *
+    * The task work counter is used to track task works in-flight for
+    * synchronization with module exit. We need to increment the task work
+    * counter before knowing if the task work add succeeded, because it may race
+    * with the task work callback's counter decrement. If the task work add
+    * failed (it only fails when the task is exiting), then we decrement the
+    * counter back to where it was. Since it's guaranteed that this function
+    * cannot be running anywhere after the probe hooks are uninstalled in module
+    * exit, decrementing the task work counter doesn't require a check to wake
+    * up the module exit waiter.
+    *
+    * On failure, we also uninit the RCU callback head so that we can track
+    * which tasks still have our task work queued.
+    */
+   atomic_inc(&p_task_work_cnt);
+   if (P_SYM_CALL(p_task_work_add, p_task, &p_task->rcu, 1 /* TWA_RESUME */)) {
+      atomic_dec(&p_task_work_cnt);
+      p_task->rcu.func = NULL;
+   }
+}
+
+static void p_ed_task_work_exit(void) {
+
+   struct task_struct *p_ptmp, *p_tmp;
+
+   if (!atomic_read(&p_task_work_cnt))
+      return;
+
+   /*
+    * Cancel all of our task works that are still enqueued. The task list lock
+    * is needed for the same reason described in p_dump_ed_tasks().
+    */
+   read_lock(P_SYM(p_tasklist_lock));
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+   for_each_process_thread(p_ptmp, p_tmp) {
+#else
+   do_each_thread(p_ptmp, p_tmp) {
+#endif
+
+      if (P_SYM_CALL(p_task_work_cancel_func, p_tmp, p_dump_task_work_cb))
+         atomic_dec(&p_task_work_cnt);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+   }
+#else
+   } while_each_thread(p_ptmp, p_tmp);
+#endif
+   read_unlock(P_SYM(p_tasklist_lock));
+
+   /* Wait for any in-flight task work callbacks to finish running */
+   wait_event(p_task_work_waitq, !atomic_read(&p_task_work_cnt));
+}
+
 static void p_dump_ed_tasks(void) {
 
    struct task_struct *p_ptmp, *p_tmp;
 
-   rcu_read_lock();
+   /*
+    * Block tasks from getting removed from the task list and possibly getting
+    * queued up for RCU free. If we overwrite a task's rcu_head after the task
+    * has been queued up for RCU free, then we will corrupt RCU's object list.
+    * This can only happen after the task is removed from the task list, so by
+    * taking the task list lock it is guaranteed that none of the tasks we see
+    * will be allowed to get RCU freed.
+    */
+   read_lock(P_SYM(p_tasklist_lock));
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    for_each_process_thread(p_ptmp, p_tmp) {
 #else
-   // tasklist_lock
    do_each_thread(p_ptmp, p_tmp) {
 #endif
 
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_tmp))
-         p_dump_task_f(p_tmp);
+         p_dump_task_work_add(p_tmp);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    }
 #else
-   // tasklist_unlock
    } while_each_thread(p_ptmp, p_tmp);
 #endif
-   rcu_read_unlock();
+   read_unlock(P_SYM(p_tasklist_lock));
 }
 
 static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
@@ -1935,6 +2044,8 @@ void p_exploit_detection_exit(void) {
       p_fh_it->uninstall();
    }
 
+   /* Cancel and wait for all ED task works to finish running */
+   p_ed_task_work_exit();
    /* Delete cache for ED wq validation */
    p_ed_wq_valid_cache_delete();
    /* Delete cache for ED CFI validation */

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -22,6 +22,8 @@ static unsigned long p_global_off_cookie;
 static unsigned long p_global_cnt_cookie;
 struct kmem_cache *p_ed_wq_valid_cache = NULL;
 static struct kmem_cache *p_ed_pcfi_cache = NULL;
+static atomic_t p_task_work_cnt = ATOMIC_INIT(0);
+static DECLARE_WAIT_QUEUE_HEAD(p_task_work_waitq);
 
 unsigned long p_pcfi_CPU_flags;
 
@@ -70,13 +72,6 @@ static const struct p_functions_hooks {
      0,
      "Won't enforce validation on 'call_usermodehelper_exec'",
      1
-   },
-   { "wake_up_new_task",
-     p_install_wake_up_new_task_hook,
-     p_uninstall_wake_up_new_task_hook,
-     1,
-     NULL,
-     0
    },
    { "do_exit",
      p_install_do_exit_hook,
@@ -262,6 +257,19 @@ static const struct p_functions_hooks {
      0,
      "Won't enforce validation on 'scm_send'",
      1
+   },
+   /*
+    * !!! DO NOT ADD NEW HOOKS AFTER THIS COMMENT !!!
+    *
+    * wake_up_new_task MUST be the last hook installed. See the comment in
+    * p_exploit_detection_init().
+    */
+   { "wake_up_new_task",
+     p_install_wake_up_new_task_hook,
+     p_uninstall_wake_up_new_task_hook,
+     1,
+     NULL,
+     0
    },
    { NULL, NULL, NULL, 1, NULL, 0 }
 };
@@ -1018,18 +1026,12 @@ void p_dump_task_f(struct task_struct *p_task) {
 #endif
 
    if (unlikely(p_insert_ed_task(p_tmp))) {
-      struct p_ed_process *p_have;
-      rcu_read_lock();
-      if ((p_have = ed_task_find_lock_rcu(p_task))) {
-         p_print_log(P_LOG_FAULT, "Duplicate key for tracking pid %u, name %s (have pid %u, name %s)",
-                     p_tmp->p_ed_task.p_pid, p_tmp->p_ed_task.p_comm,
-                     p_have->p_ed_task.p_pid, p_have->p_ed_task.p_comm);
-         ed_task_unlock(p_have);
-      } else {
-         p_print_log(P_LOG_FAULT, "Duplicate key for tracking pid %u, name %s",
-                     p_tmp->p_ed_task.p_pid, p_tmp->p_ed_task.p_comm);
-      }
-      rcu_read_unlock();
+      /*
+       * The task is already in the ED tree. This is normal at init because the
+       * wake_up_new_task probe is installed before the initial task dump, so a
+       * newly forked task may be added by the probe and then get added again
+       * during the task dump.
+       */
       free_ed_task(p_tmp);
    } else {
       p_print_log(P_LOG_WATCH, "Inserting pid %u, name %s",
@@ -1037,17 +1039,110 @@ void p_dump_task_f(struct task_struct *p_task) {
    }
 }
 
+static void p_dump_task_work_cb(struct callback_head *work) {
+
+   struct task_struct *p_task = current;
+
+   kfree(work);
+
+   /*
+    * When a task exits, exit_task_work() flushes all the queued task workers.
+    * This occurs after PF_EXITING is set for the exiting task. As such, we can
+    * check for PF_EXITING to know if we are getting called after the task has
+    * entered do_exit(), and the check isn't racy. This way, we won't leak
+    * memory allocating an ed struct after our do_exit() kprobe that frees it.
+    */
+   if (!(p_task->flags & PF_EXITING))
+      p_dump_task_f(p_task);
+
+   /*
+    * Decrement the task work counter and wake up the module exit thread if
+    * there are no more task works in flight and it happens to be waiting. The
+    * atomic_dec_and_test() executes a full memory barrier, providing the
+    * necessary ordering before the lockless waitqueue_active() check so that a
+    * wake-up won't be missed (which would make module exit hang forever).
+    */
+   if (atomic_dec_and_test(&p_task_work_cnt) &&
+       waitqueue_active(&p_task_work_waitq))
+      wake_up(&p_task_work_waitq);
+}
+
+static void p_dump_task_work_add(struct task_struct *p_task,
+                                 struct callback_head **p_work) {
+
+   struct callback_head *work = p_work ? *p_work : NULL;
+
+   if (!work) {
+      work = kmalloc(sizeof(*work), GFP_ATOMIC);
+      if (!work)
+         return;
+   }
+
+   init_task_work(work, p_dump_task_work_cb);
+
+   /*
+    * Add the task work so it fires right before the task returns to userspace.
+    * If the task is currently running in userspace, it'll be kicked into the
+    * kernel so it runs soon. If the task is sleeping, it won't be woken up
+    * since there's no need to; a sleeping task can't do anything malicious.
+    *
+    * The task work counter tracks in-flight task works for synchronization
+    * with module exit. We need to increment the counter before task_work_add()
+    * because the callback's decrement may race with us. If task_work_add()
+    * fails (it only fails when the task is exiting), we just decrement the
+    * counter back. This function can't be running anywhere after the probe
+    * hooks are uninstalled in module exit, so the decrement doesn't need to
+    * check if the module exit waiter needs a wake-up.
+    */
+   atomic_inc(&p_task_work_cnt);
+   if (P_SYM_CALL(p_task_work_add, p_task, work, 1 /* TWA_RESUME */))
+      atomic_dec(&p_task_work_cnt);
+   else
+      work = NULL;
+
+   /* On failure, save the buffer for reuse if requested, otherwise free it */
+   if (p_work)
+      *p_work = work;
+   else
+      kfree(work);
+}
+
+static void p_ed_task_work_exit(void) {
+
+   struct task_struct *p_ptmp, *p_tmp;
+   struct callback_head *work;
+
+   if (!atomic_read(&p_task_work_cnt))
+      return;
+
+   rcu_read_lock();
+   for_each_process_thread(p_ptmp, p_tmp) {
+      work = P_SYM_CALL(p_task_work_cancel_func, p_tmp, p_dump_task_work_cb);
+      if (work) {
+         kfree(work);
+         atomic_dec(&p_task_work_cnt);
+      }
+   }
+   rcu_read_unlock();
+
+   /* Wait for any in-flight task work callbacks to finish running */
+   wait_event(p_task_work_waitq, !atomic_read(&p_task_work_cnt));
+}
+
 static void p_dump_ed_tasks(void) {
 
    struct task_struct *p_ptmp, *p_tmp;
+   struct callback_head *work = NULL;
 
    rcu_read_lock();
    for_each_process_thread(p_ptmp, p_tmp) {
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_tmp))
-         p_dump_task_f(p_tmp);
+         p_dump_task_work_add(p_tmp, &work);
    }
    rcu_read_unlock();
+
+   kfree(work);
 }
 
 static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
@@ -1879,9 +1974,18 @@ int p_exploit_detection_init(void) {
       return P_LKRG_GENERAL_ERROR;
    }
 
-   // Dump processes and threads
-   p_dump_ed_tasks();
-
+   /*
+    * Install all probes *before* the initial task dump. If a task were added to
+    * the ED tree while in middle of a probed code path, then the task's shadow
+    * state could be garbage. Since no tasks are in the ED tree yet, the probe
+    * handlers will just see untracked tasks and safely skip them.
+    *
+    * The wake_up_new_task probe is installed last (it's at the end of the
+    * array) because it adds new tasks to the ED tree, so all other probes need
+    * to be in place first. The task dump uses task works, which fire when the
+    * target task returns to userspace, so the task is guaranteed to be outside
+    * of any probed code path when it is added to the ED tree.
+    */
    for (p_fh_it = p_functions_hooks_array; p_fh_it->name != NULL; p_fh_it++) {
       if (p_fh_it->install(p_fh_it->is_isra_safe)) {
          if (!p_fh_it->p_fatal) {
@@ -1892,6 +1996,8 @@ int p_exploit_detection_init(void) {
          return P_LKRG_GENERAL_ERROR;
       }
    }
+
+   p_dump_ed_tasks();
 
    return P_LKRG_SUCCESS;
 
@@ -1912,6 +2018,8 @@ void p_exploit_detection_exit(void) {
       p_fh_it->uninstall();
    }
 
+   /* Cancel and wait for all ED task works to finish running */
+   p_ed_task_work_exit();
    /* Delete cache for ED wq validation */
    p_ed_wq_valid_cache_delete();
    /* Delete cache for ED CFI validation */

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1043,23 +1043,11 @@ static void p_dump_ed_tasks(void) {
    struct task_struct *p_ptmp, *p_tmp;
 
    rcu_read_lock();
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    for_each_process_thread(p_ptmp, p_tmp) {
-#else
-   // tasklist_lock
-   do_each_thread(p_ptmp, p_tmp) {
-#endif
-
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_tmp))
          p_dump_task_f(p_tmp);
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    }
-#else
-   // tasklist_unlock
-   } while_each_thread(p_ptmp, p_tmp);
-#endif
    rcu_read_unlock();
 }
 
@@ -1070,12 +1058,7 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
    struct task_struct *p_ptmp, *p_task;
 
    rcu_read_lock();
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    for_each_process_thread(p_ptmp, p_task) {
-#else
-   do_each_thread(p_ptmp, p_task) {
-#endif
-
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_task) && p_get_task_state(p_task) != TASK_DEAD) {
          if ((p_tmp = ed_task_find_lock_rcu(p_task))) {
@@ -1086,12 +1069,7 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
             ed_task_unlock(p_tmp);
          }
       }
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    }
-#else
-   } while_each_thread(p_ptmp, p_task);
-#endif
    rcu_read_unlock();
 
    /* Before leaving, verify current task */

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1002,7 +1002,7 @@ static int p_insert_ed_task(struct p_ed_process *p_source) {
    return ret;
 }
 
-void p_dump_task_f(void *p_arg) {
+static void p_dump_task_f(void *p_arg) {
 
    struct task_struct *p_task = (struct task_struct *)p_arg;
    struct p_ed_process *p_tmp;
@@ -1072,7 +1072,7 @@ static void p_dump_task_work_cb(struct callback_head *head) {
       wake_up(&p_task_work_waitq);
 }
 
-static void p_dump_task_work_add(struct task_struct *p_task) {
+void p_dump_task_work_add(struct task_struct *p_task) {
 
    /*
     * Leverage the RCU callback head in task_struct for memory in order to queue

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1008,14 +1008,9 @@ static int p_insert_ed_task(struct p_ed_process *p_source) {
    return ret;
 }
 
-void p_dump_task_f(struct task_struct *p_task) {
+static void p_dump_task_f(struct task_struct *p_task) {
 
-   struct p_ed_process *p_tmp;
-
-   if (unlikely((p_tmp = alloc_ed_task(p_task)) == NULL)) {
-      p_print_log(P_LOG_FAULT, "Can't allocate memory for tracking pid %u, name %s", p_task->pid, p_task->comm);
-      return;
-   }
+   struct p_ed_process *p_tmp = alloc_ed_task(p_task); /* Never fails */
 
    p_update_ed_process(p_tmp, 1);
 //   p_set_ed_process_on(p_tmp);
@@ -1067,8 +1062,8 @@ static void p_dump_task_work_cb(struct callback_head *work) {
       wake_up(&p_task_work_waitq);
 }
 
-static void p_dump_task_work_add(struct task_struct *p_task,
-                                 struct callback_head **p_work) {
+void p_dump_task_work_add(struct task_struct *p_task,
+                          struct callback_head **p_work) {
 
    struct callback_head *work = p_work ? *p_work : NULL;
 

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1020,9 +1020,8 @@ static int p_insert_ed_task(struct p_ed_process *p_source) {
    return ret;
 }
 
-void p_dump_task_f(void *p_arg) {
+void p_dump_task_f(struct task_struct *p_task) {
 
-   struct task_struct *p_task = (struct task_struct *)p_arg;
    struct p_ed_process *p_tmp;
 
    if (unlikely((p_tmp = alloc_ed_task(p_task)) == NULL)) {

--- a/src/modules/exploit_detection/p_exploit_detection.c
+++ b/src/modules/exploit_detection/p_exploit_detection.c
@@ -1063,23 +1063,11 @@ static void p_dump_ed_tasks(void) {
    struct task_struct *p_ptmp, *p_tmp;
 
    rcu_read_lock();
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    for_each_process_thread(p_ptmp, p_tmp) {
-#else
-   // tasklist_lock
-   do_each_thread(p_ptmp, p_tmp) {
-#endif
-
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_tmp))
          p_dump_task_f(p_tmp);
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    }
-#else
-   // tasklist_unlock
-   } while_each_thread(p_ptmp, p_tmp);
-#endif
    rcu_read_unlock();
 }
 
@@ -1090,12 +1078,7 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
    struct task_struct *p_ptmp, *p_task;
 
    rcu_read_lock();
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    for_each_process_thread(p_ptmp, p_task) {
-#else
-   do_each_thread(p_ptmp, p_task) {
-#endif
-
       /* do not touch kernel threads or the global init */
       if (p_is_ed_task(p_task) && p_get_task_state(p_task) != TASK_DEAD) {
          if ((p_tmp = ed_task_find_lock_rcu(p_task))) {
@@ -1106,12 +1089,7 @@ static unsigned int p_iterate_lkrg_tasks_paranoid(void) {
             ed_task_unlock(p_tmp);
          }
       }
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
    }
-#else
-   } while_each_thread(p_ptmp, p_task);
-#endif
    rcu_read_unlock();
 
    /* Before leaving, verify current task */

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -326,7 +326,7 @@ static inline void p_kill_task_by_task(struct task_struct *p_task) {
 extern struct p_ed_global_variables p_ed_guard_globals;
 extern unsigned long p_pcfi_CPU_flags;
 
-void p_dump_task_f(void *p_arg);
+void p_dump_task_f(struct task_struct *p_task);
 
 void p_verify_addr_limit(struct p_ed_process *p_orig);
 void p_update_ed_process(struct p_ed_process *p_source, char p_stack);

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -326,7 +326,8 @@ static inline void p_kill_task_by_task(struct task_struct *p_task) {
 extern struct p_ed_global_variables p_ed_guard_globals;
 extern unsigned long p_pcfi_CPU_flags;
 
-void p_dump_task_f(struct task_struct *p_task);
+void p_dump_task_work_add(struct task_struct *p_task,
+                          struct callback_head **p_work);
 
 void p_verify_addr_limit(struct p_ed_process *p_orig);
 void p_update_ed_process(struct p_ed_process *p_source, char p_stack);

--- a/src/modules/exploit_detection/p_exploit_detection.h
+++ b/src/modules/exploit_detection/p_exploit_detection.h
@@ -326,7 +326,7 @@ static inline void p_kill_task_by_task(struct task_struct *p_task) {
 extern struct p_ed_global_variables p_ed_guard_globals;
 extern unsigned long p_pcfi_CPU_flags;
 
-void p_dump_task_f(void *p_arg);
+void p_dump_task_work_add(struct task_struct *p_task);
 
 void p_verify_addr_limit(struct p_ed_process *p_orig);
 void p_update_ed_process(struct p_ed_process *p_source, char p_stack);

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -26,7 +26,7 @@ static int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs)
    struct task_struct *p_task = (struct task_struct *)p_regs_get_arg1(p_regs);
 
    if (p_is_ed_task(p_task))
-      p_dump_task_f(p_task);
+      p_dump_task_work_add(p_task, NULL);
 
    p_ed_enforce_validation();
 

--- a/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
+++ b/src/modules/exploit_detection/syscalls/p_wake_up_new_task/p_wake_up_new_task.c
@@ -26,7 +26,7 @@ static int p_wake_up_new_task_entry(struct kprobe *p_ri, struct pt_regs *p_regs)
    struct task_struct *p_task = (struct task_struct *)p_regs_get_arg1(p_regs);
 
    if (p_is_ed_task(p_task))
-      p_dump_task_f(p_task);
+      p_dump_task_work_add(p_task);
 
    p_ed_enforce_validation();
 

--- a/src/modules/print_log/p_lkrg_debug_log.c
+++ b/src/modules/print_log/p_lkrg_debug_log.c
@@ -38,7 +38,7 @@ static struct p_addr_name {
    P_LKRG_DEBUG_RULE(ed_task_del_current),
    P_LKRG_DEBUG_RULE(__ed_task_find_rcu),
    P_LKRG_DEBUG_RULE(__ed_task_current),
-   P_LKRG_DEBUG_RULE(p_dump_task_f),
+   P_LKRG_DEBUG_RULE(p_dump_task_work_add),
    P_LKRG_DEBUG_RULE(p_ed_enforce_validation),
    P_LKRG_DEBUG_RULE(p_ed_enforce_validation_paranoid),
    P_LKRG_DEBUG_RULE(p_exploit_detection_init),

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -94,8 +94,6 @@ p_ro_page p_ro = {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreturn-type"
 GENERATE_CALL_FUNC(unsigned long, p_kallsyms_lookup_name, const char *name)
-GENERATE_CALL_FUNC(int, p_freeze_processes, void)
-GENERATE_CALL_FUNC(void, p_thaw_processes, void)
 #if !defined(CONFIG_ARM64)
  GENERATE_CALL_FUNC(void, p_flush_tlb_all, void)
 #endif
@@ -138,6 +136,8 @@ GENERATE_CALL_FUNC(int, p_kallsyms_on_each_symbol, int (*fn)(void *, const char 
 #if defined(CONFIG_OPTPROBES)
  GENERATE_CALL_FUNC(void, p_wait_for_kprobe_optimizer, void)
 #endif
+GENERATE_CALL_FUNC(int, p_task_work_add, struct task_struct *, struct callback_head *, int)
+GENERATE_CALL_FUNC(struct callback_head *, p_task_work_cancel_func, struct task_struct *, task_work_func_t)
 #pragma GCC diagnostic pop
 #endif
 
@@ -424,65 +424,6 @@ static void p_parse_module_params(void) {
 
 }
 
-static void __init p_freeze_userspace(void) {
-
-   unsigned int timeout, tries, orig_timeout, sleep_ms;
-
-   /* Save the original freeze timeout that may have been set by the user */
-   orig_timeout = *P_SYM(p_freeze_timeout_msecs);
-
-   /* Start with a freeze timeout of 2000 ms and a sleep duration of 100 ms */
-   timeout = min(2000U, orig_timeout);
-   sleep_ms = 100;
-
-   /*
-    * Freeze all user tasks with incremental timeouts and sleeps in between. The
-    * reason for starting with a shorter timeout is that a task blocking the
-    * freeze may depend on work from an already-frozen task in order to become
-    * unblocked. In this case, the freeze attempt will always continue until the
-    * timeout is reached, resulting in a long stall where most of userspace is
-    * frozen. The blocking task will always be running somewhere in the kernel,
-    * which is why it is blocking in the first place: it can't just teleport
-    * into the refrigerator when it's already stuck in some other kernel code.
-    *
-    * Some systems may legitimately require more time in order to freeze all
-    * user tasks, which is accommodated by incrementally scaling up the timeout
-    * duration.
-    *
-    * After a failed freeze attempt, we must wait a little bit to allow the
-    * blocking tasks to hopefully make enough forward progress to become
-    * unblocked. There's no precise way to track this, as the freezer is
-    * completely unaware of inter-process dependencies that must be satisfied to
-    * unblock a task.
-    */
-   *P_SYM(p_freeze_timeout_msecs) = timeout;
-   for (tries = 1; P_SYM_CALL(p_freeze_processes); tries++) {
-      /* Scale up after every 3 failed attempts */
-      if (!(tries % 3)) {
-         /* Don't sleep longer than 500 ms at a time (it probably won't help) */
-         sleep_ms = min(sleep_ms + 100, 500U);
-
-         /* Increase the timeout, capping it to the original timeout duration */
-         timeout = min(timeout * 2, orig_timeout);
-         *P_SYM(p_freeze_timeout_msecs) = timeout;
-      }
-
-      p_print_log(P_LOG_ISSUE, "Freezing failed %u time(s), sleeping %u ms before next try with timeout of %u ms",
-                  tries, sleep_ms, timeout);
-
-      /* Sleep for a bit to give blocking tasks some time to become unblocked */
-      msleep(sleep_ms);
-   }
-
-   /*
-    * Restore the original freeze timeout. We may overwrite a userspace change
-    * to the freeze timeout via /sys/power/pm_freeze_timeout if the change
-    * occurred between when we cached the original timeout and now. This
-    * shouldn't be a big deal.
-    */
-   *P_SYM(p_freeze_timeout_msecs) = orig_timeout;
-}
-
 /*
  * Main entry point for the module - initialization.
  */
@@ -490,7 +431,6 @@ static int __init p_lkrg_register(void) {
 
    int p_ret = P_LKRG_SUCCESS;
    char p_cpu = 0;
-   char p_freeze = 0;
 
    lkrg_register_net();
 
@@ -543,9 +483,6 @@ static int __init p_lkrg_register(void) {
       return P_LKRG_GENERAL_ERROR;
    }
 
-   P_SYM_INIT(freeze_timeout_msecs)
-   P_SYM_INIT(freeze_processes)
-   P_SYM_INIT(thaw_processes)
 #if defined(CONFIG_X86) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
    P_SYM_INIT(native_write_cr4)
 #endif
@@ -556,11 +493,16 @@ static int __init p_lkrg_register(void) {
 #if defined(CONFIG_OPTPROBES)
    P_SYM_INIT(wait_for_kprobe_optimizer)
 #endif
+   P_SYM_INIT(task_work_add)
 
-   // Freeze all non-kernel processes
-   p_freeze_userspace();
-
-   p_freeze = 1;
+   /*
+    * task_work_cancel_func() is called task_work_cancel() in older kernels.
+    * Attempt to find task_work_cancel_func() first since newer kernels also
+    * have task_work_cancel() which does something different. If that fails,
+    * then try to find task_work_cancel().
+    */
+   if (!P_SYM_INIT_NO_ERROR(task_work_cancel_func))
+      P_SYM_INIT_VAR(task_work_cancel_func, task_work_cancel)
 
    /*
     * First, we need to plant *kprobes... Before DB is created!
@@ -692,11 +634,6 @@ p_main_error:
 #endif
    }
 
-   if (p_freeze) {
-      // Thaw all non-kernel processes
-      P_SYM_CALL(p_thaw_processes);
-   }
-
    if (p_ret != P_LKRG_SUCCESS)
       lkrg_deregister_net();
 
@@ -720,11 +657,6 @@ static void __exit p_lkrg_deregister(void) {
    p_deregister_notifiers();
    if (p_timer.function)
       del_timer_sync(&p_timer);
-
-
-   // Freeze all non-kernel processes
-   while (P_SYM_CALL(p_freeze_processes))
-      schedule();
 
    p_deregister_comm_channel();
 
@@ -753,9 +685,6 @@ static void __exit p_lkrg_deregister(void) {
    if (p_db.kernel_stext_copy)
       vfree(p_db.kernel_stext_copy);
 #endif
-
-   // Thaw all non-kernel processes
-   P_SYM_CALL(p_thaw_processes);
 
    p_print_log(P_LOG_DYING, "LKRG unloaded");
 

--- a/src/p_lkrg_main.c
+++ b/src/p_lkrg_main.c
@@ -94,8 +94,6 @@ p_ro_page p_ro = {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreturn-type"
 GENERATE_CALL_FUNC(unsigned long, p_kallsyms_lookup_name, const char *name)
-GENERATE_CALL_FUNC(int, p_freeze_processes, void)
-GENERATE_CALL_FUNC(void, p_thaw_processes, void)
 #if !defined(CONFIG_ARM64)
  GENERATE_CALL_FUNC(void, p_flush_tlb_all, void)
 #endif
@@ -138,6 +136,8 @@ GENERATE_CALL_FUNC(int, p_kallsyms_on_each_symbol, int (*fn)(void *, const char 
 #if defined(CONFIG_OPTPROBES)
  GENERATE_CALL_FUNC(void, p_wait_for_kprobe_optimizer, void)
 #endif
+GENERATE_CALL_FUNC(int, p_task_work_add, struct task_struct *, struct callback_head *, int)
+GENERATE_CALL_FUNC(struct callback_head *, p_task_work_cancel_func, struct task_struct *, task_work_func_t)
 #pragma GCC diagnostic pop
 #endif
 
@@ -424,65 +424,6 @@ static void p_parse_module_params(void) {
 
 }
 
-static void __init p_freeze_userspace(void) {
-
-   unsigned int timeout, tries, orig_timeout, sleep_ms;
-
-   /* Save the original freeze timeout that may have been set by the user */
-   orig_timeout = *P_SYM(p_freeze_timeout_msecs);
-
-   /* Start with a freeze timeout of 500 ms and a sleep duration of 50 ms */
-   timeout = min(500, orig_timeout);
-   sleep_ms = 50;
-
-   /*
-    * Freeze all user tasks with incremental timeouts and sleeps in between. The
-    * reason for starting with a shorter timeout is that a task blocking the
-    * freeze may depend on work from an already-frozen task in order to become
-    * unblocked. In this case, the freeze attempt will always continue until the
-    * timeout is reached, resulting in a long stall where most of userspace is
-    * frozen. The blocking task will always be running somewhere in the kernel,
-    * which is why it is blocking in the first place: it can't just teleport
-    * into the refrigerator when it's already stuck in some other kernel code.
-    *
-    * Some systems may legitimately require more time in order to freeze all
-    * user tasks, which is accommodated by incrementally scaling up the timeout
-    * duration.
-    *
-    * After a failed freeze attempt, we must wait a little bit to allow the
-    * blocking tasks to hopefully make enough forward progress to become
-    * unblocked. There's no precise way to track this, as the freezer is
-    * completely unaware of inter-process dependencies that must be satisfied to
-    * unblock a task.
-    */
-   *P_SYM(p_freeze_timeout_msecs) = timeout;
-   for (tries = 1; P_SYM_CALL(p_freeze_processes); tries++) {
-      /* Scale up after every 3 failed attempts */
-      if (!(tries % 3)) {
-         /* Don't sleep longer than 500 ms at a time (it probably won't help) */
-         sleep_ms = min(sleep_ms + 50, 500);
-
-         /* Increase the timeout, capping it to the original timeout duration */
-         timeout = min(timeout * 2, orig_timeout);
-         *P_SYM(p_freeze_timeout_msecs) = timeout;
-      }
-
-      p_print_log(P_LOG_ISSUE, "Freezing failed %u time(s), sleeping %u ms before next try with timeout of %u ms",
-                  tries, sleep_ms, timeout);
-
-      /* Sleep for a bit to give blocking tasks some time to become unblocked */
-      msleep(sleep_ms);
-   }
-
-   /*
-    * Restore the original freeze timeout. We may overwrite a userspace change
-    * to the freeze timeout via /sys/power/pm_freeze_timeout if the change
-    * occurred between when we cached the original timeout and now. This
-    * shouldn't be a big deal.
-    */
-   *P_SYM(p_freeze_timeout_msecs) = orig_timeout;
-}
-
 /*
  * Main entry point for the module - initialization.
  */
@@ -490,7 +431,6 @@ static int __init p_lkrg_register(void) {
 
    int p_ret = P_LKRG_SUCCESS;
    char p_cpu = 0;
-   char p_freeze = 0;
 
    lkrg_register_net();
 
@@ -543,9 +483,6 @@ static int __init p_lkrg_register(void) {
       return P_LKRG_GENERAL_ERROR;
    }
 
-   P_SYM_INIT(freeze_timeout_msecs)
-   P_SYM_INIT(freeze_processes)
-   P_SYM_INIT(thaw_processes)
 #if defined(CONFIG_X86) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
    P_SYM_INIT(native_write_cr4)
 #endif
@@ -556,11 +493,17 @@ static int __init p_lkrg_register(void) {
 #if defined(CONFIG_OPTPROBES)
    P_SYM_INIT(wait_for_kprobe_optimizer)
 #endif
+   P_SYM_INIT(tasklist_lock)
+   P_SYM_INIT(task_work_add)
 
-   // Freeze all non-kernel processes
-   p_freeze_userspace();
-
-   p_freeze = 1;
+   /*
+    * task_work_cancel_func() is called task_work_cancel() in older kernels.
+    * Attempt to find task_work_cancel_func() first since newer kernels also
+    * have task_work_cancel() which does something different. If that fails,
+    * then try to find task_work_cancel().
+    */
+   if (!P_SYM_INIT_NO_ERROR(task_work_cancel_func))
+      P_SYM_INIT_VAR(task_work_cancel_func, task_work_cancel)
 
    /*
     * First, we need to plant *kprobes... Before DB is created!
@@ -692,11 +635,6 @@ p_main_error:
 #endif
    }
 
-   if (p_freeze) {
-      // Thaw all non-kernel processes
-      P_SYM_CALL(p_thaw_processes);
-   }
-
    if (p_ret != P_LKRG_SUCCESS)
       lkrg_deregister_net();
 
@@ -720,11 +658,6 @@ static void __exit p_lkrg_deregister(void) {
    p_deregister_notifiers();
    if (p_timer.function)
       del_timer_sync(&p_timer);
-
-
-   // Freeze all non-kernel processes
-   while (P_SYM_CALL(p_freeze_processes))
-      schedule();
 
    p_deregister_comm_channel();
 
@@ -753,9 +686,6 @@ static void __exit p_lkrg_deregister(void) {
    if (p_db.kernel_stext_copy)
       vfree(p_db.kernel_stext_copy);
 #endif
-
-   // Thaw all non-kernel processes
-   P_SYM_CALL(p_thaw_processes);
 
    p_print_log(P_LOG_DYING, "LKRG unloaded");
 

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -44,6 +44,7 @@
 #include <linux/usb.h>
 #include <linux/acpi.h>
 #include <linux/profile.h>
+#include <linux/task_work.h>
 
 #include <linux/kprobes.h>
 #include <linux/namei.h>
@@ -196,9 +197,6 @@ typedef struct _p_lkrg_global_conf_structure {
 typedef struct _p_lkrg_global_symbols_structure {
 
    unsigned long (*p_kallsyms_lookup_name)(const char *name);
-   unsigned int *p_freeze_timeout_msecs;
-   int (*p_freeze_processes)(void);
-   void (*p_thaw_processes)(void);
 #if !defined(CONFIG_ARM64)
    void (*p_flush_tlb_all)(void);
 #endif
@@ -280,6 +278,26 @@ typedef struct _p_lkrg_global_symbols_structure {
 #endif
    struct module *p_find_me;
    unsigned int p_state_init;
+
+   /*
+    * There are three variants for the type of the notify argument to
+    * task_work_add(): bool, int, and enum task_work_notify_mode. On newer
+    * kernels which have either int or enum task_work_notify_mode, we want to
+    * pass TWA_RESUME. On older kernels which have bool, we want to pass true.
+    * As it happens, TWA_RESUME is 1, so we can use a single prototype that's
+    * compatible with all variants by just using int. These changes to the type
+    * of the notify argument were backported to stable kernels, so it would be
+    * difficult to try and create a kernel version #if check for the right type.
+    *
+    * Always using int is safe because bool, int, and enum are all passed
+    * interchangeably in function calls on every Linux arch. An enum is the same
+    * size as an int since the kernel doesn't use -fshort-enums, so passing 1 as
+    * an int works whether the function takes a bool, int, or enum.
+    */
+   int (*p_task_work_add)(struct task_struct *task, struct callback_head *work,
+                          int notify);
+   struct callback_head *(*p_task_work_cancel_func)(struct task_struct *task,
+                                                    task_work_func_t func);
 
 } p_lkrg_global_syms;
 
@@ -392,8 +410,6 @@ extern p_ro_page p_ro;
    extern type call_##name(__VA_ARGS__);
 
 GENERATE_CALL_FUNC_PROTO(unsigned long, p_kallsyms_lookup_name, const char *name)
-GENERATE_CALL_FUNC_PROTO(int, p_freeze_processes, void)
-GENERATE_CALL_FUNC_PROTO(void, p_thaw_processes, void)
 #if !defined(CONFIG_ARM64)
  GENERATE_CALL_FUNC_PROTO(void, p_flush_tlb_all, void)
 #endif
@@ -437,6 +453,8 @@ GENERATE_CALL_FUNC_PROTO(int, p_kallsyms_on_each_symbol,
 #if defined(CONFIG_OPTPROBES)
  GENERATE_CALL_FUNC_PROTO(void, p_wait_for_kprobe_optimizer, void)
 #endif
+GENERATE_CALL_FUNC_PROTO(int, p_task_work_add, struct task_struct *, struct callback_head *, int)
+GENERATE_CALL_FUNC_PROTO(struct callback_head *, p_task_work_cancel_func, struct task_struct *, task_work_func_t)
 
 #define P_SYM_CALL(name, ...) \
    call_##name(__VA_ARGS__)
@@ -448,11 +466,20 @@ GENERATE_CALL_FUNC_PROTO(int, p_kallsyms_on_each_symbol,
 
 #endif
 
-#define P_SYM_INIT(sym) \
-   if (!(P_SYM(p_ ## sym) = (typeof(P_SYM(p_ ## sym)))P_SYM_CALL(p_kallsyms_lookup_name, #sym))) { \
+#define P_SYM_INIT_VAR_NO_ERROR(var, sym) \
+   (P_SYM(p_ ## var) = (typeof(P_SYM(p_ ## var)))P_SYM_CALL(p_kallsyms_lookup_name, #sym))
+
+#define P_SYM_INIT_NO_ERROR(sym) \
+   P_SYM_INIT_VAR_NO_ERROR(sym, sym)
+
+#define P_SYM_INIT_VAR(var, sym) \
+   if (!P_SYM_INIT_VAR_NO_ERROR(var, sym)) { \
       p_print_log(P_LOG_FATAL, "Can't find '" #sym "'"); \
       goto p_sym_error; \
    }
+
+#define P_SYM_INIT(sym) \
+   P_SYM_INIT_VAR(sym, sym)
 
 /*
  * LKRG counter lock

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -44,6 +44,7 @@
 #include <linux/usb.h>
 #include <linux/acpi.h>
 #include <linux/profile.h>
+#include <linux/task_work.h>
 
 #include <linux/kprobes.h>
 #include <linux/namei.h>
@@ -190,9 +191,6 @@ typedef struct _p_lkrg_global_conf_structure {
 typedef struct _p_lkrg_global_symbols_structure {
 
    unsigned long (*p_kallsyms_lookup_name)(const char *name);
-   unsigned int *p_freeze_timeout_msecs;
-   int (*p_freeze_processes)(void);
-   void (*p_thaw_processes)(void);
 #if !defined(CONFIG_ARM64)
    void (*p_flush_tlb_all)(void);
 #endif
@@ -274,6 +272,22 @@ typedef struct _p_lkrg_global_symbols_structure {
 #endif
    struct module *p_find_me;
    unsigned int p_state_init;
+   rwlock_t *p_tasklist_lock;
+
+   /*
+    * Note that there are three variants for the type of the notify argument to
+    * task_work_add(): bool, int, and enum task_work_notify_mode. On newer
+    * kernels which have either int or enum task_work_notify_mode, we want to
+    * pass TWA_RESUME. On older kernels which have bool, we want to pass true.
+    * As it happens, TWA_RESUME is 1, so we can use a single prototype that's
+    * compatible with all variants by just using int. These changes to the type
+    * on the notify argument were backported to stable kernels, so it would be
+    * difficult to try and create a kernel version #if check for the right type.
+    */
+   int (*p_task_work_add)(struct task_struct *task, struct callback_head *work,
+		                    int notify);
+   struct callback_head *(*p_task_work_cancel_func)(struct task_struct *task,
+                                                    task_work_func_t func);
 
 } p_lkrg_global_syms;
 
@@ -386,8 +400,6 @@ extern p_ro_page p_ro;
    extern type call_##name(__VA_ARGS__);
 
 GENERATE_CALL_FUNC_PROTO(unsigned long, p_kallsyms_lookup_name, const char *name)
-GENERATE_CALL_FUNC_PROTO(int, p_freeze_processes, void)
-GENERATE_CALL_FUNC_PROTO(void, p_thaw_processes, void)
 #if !defined(CONFIG_ARM64)
  GENERATE_CALL_FUNC_PROTO(void, p_flush_tlb_all, void)
 #endif
@@ -431,6 +443,8 @@ GENERATE_CALL_FUNC_PROTO(int, p_kallsyms_on_each_symbol,
 #if defined(CONFIG_OPTPROBES)
  GENERATE_CALL_FUNC_PROTO(void, p_wait_for_kprobe_optimizer, void)
 #endif
+GENERATE_CALL_FUNC_PROTO(int, p_task_work_add, struct task_struct *, struct callback_head *, int)
+GENERATE_CALL_FUNC_PROTO(struct callback_head *, p_task_work_cancel_func, struct task_struct *, task_work_func_t)
 
 #define P_SYM_CALL(name, ...) \
    call_##name(__VA_ARGS__)
@@ -442,11 +456,20 @@ GENERATE_CALL_FUNC_PROTO(int, p_kallsyms_on_each_symbol,
 
 #endif
 
-#define P_SYM_INIT(sym) \
-   if (!(P_SYM(p_ ## sym) = (typeof(P_SYM(p_ ## sym)))P_SYM_CALL(p_kallsyms_lookup_name, #sym))) { \
+#define P_SYM_INIT_VAR_NO_ERROR(var, sym) \
+   (P_SYM(p_ ## var) = (typeof(P_SYM(p_ ## var)))P_SYM_CALL(p_kallsyms_lookup_name, #sym))
+
+#define P_SYM_INIT_NO_ERROR(sym) \
+   P_SYM_INIT_VAR_NO_ERROR(sym, sym)
+
+#define P_SYM_INIT_VAR(var, sym) \
+   if (!P_SYM_INIT_VAR_NO_ERROR(var, sym)) { \
       p_print_log(P_LOG_FATAL, "Can't find '" #sym "'"); \
       goto p_sym_error; \
    }
+
+#define P_SYM_INIT(sym) \
+   P_SYM_INIT_VAR(sym, sym)
 
 /*
  * LKRG counter lock

--- a/src/p_lkrg_main.h
+++ b/src/p_lkrg_main.h
@@ -100,6 +100,12 @@ static inline unsigned long get_random_long(void) {
 #define p_read_cpu_unlock cpus_read_unlock
 #endif
 
+/* for_each_process_thread() was introduced in v3.14 */
+#ifndef for_each_process_thread
+#define for_each_process_thread(p, t)	\
+   for_each_process(p) for_each_thread(p, t)
+#endif
+
 #include <linux/stacktrace.h>
 #include <asm/stacktrace.h>
 #include <asm/tlbflush.h>


### PR DESCRIPTION
Sanity tested by printing all tasks added to the ED tree.