### PR TITLE
lkrg: Replacing GFP_ATOMIC with GFP_NOFS(Fixes #487)

### DIFF
--- a/src/modules/kmod/p_kmod.c
+++ b/src/modules/kmod/p_kmod.c
@@ -403,7 +403,7 @@ int p_kmod_hash(unsigned int *p_module_list_cnt_arg, p_module_list_mem **p_mlm_t
        * 'safe' flag anymore, we are spinning until allocation succeeds.
        */
       if ( (*p_mlm_tmp = kzalloc(sizeof(p_module_list_mem) * (*p_module_list_cnt_arg+P_MODULE_BUFFER_RACE),
-                                 GFP_ATOMIC)) == NULL) {
+                                 GFP_NOFS)) == NULL) {
          /*
           * I should NEVER be here!
           */
@@ -432,7 +432,7 @@ int p_kmod_hash(unsigned int *p_module_list_cnt_arg, p_module_list_mem **p_mlm_t
        * 'safe' flag anymore, we are spinning until allocation succeeds.
        */
       if ( (*p_mkm_tmp = kzalloc(sizeof(p_module_kobj_mem) * (*p_module_kobj_cnt_arg+P_MODULE_BUFFER_RACE),
-                                 GFP_ATOMIC)) == NULL) {
+                                 GFP_NOFS)) == NULL) {
          /*
           * I should NEVER be here!
           */
@@ -471,7 +471,7 @@ int p_kmod_hash(unsigned int *p_module_list_cnt_arg, p_module_list_mem **p_mlm_t
           * 'safe' flag anymore, we are spinning until allocation succeeds.
           */
          if ( (*p_mlm_tmp = kzalloc(sizeof(p_module_list_mem) * (*p_module_list_cnt_arg+P_MODULE_BUFFER_RACE),
-                                    GFP_ATOMIC)) == NULL) {
+                                    GFP_NOFS)) == NULL) {
             /*
              * I should NEVER be here!
              */
@@ -511,7 +511,7 @@ int p_kmod_hash(unsigned int *p_module_list_cnt_arg, p_module_list_mem **p_mlm_t
           * 'safe' flag anymore, we are spinning until allocation succeeds.
           */
          if ( (*p_mkm_tmp = kzalloc(sizeof(p_module_kobj_mem) * (*p_module_kobj_cnt_arg+P_MODULE_BUFFER_RACE),
-                                    GFP_ATOMIC)) == NULL) {
+                                    GFP_NOFS)) == NULL) {
             /*
              * I should NEVER be here!
              */


### PR DESCRIPTION
### Description

Replacing GFP_ATOMIC with GFP_NOFS (prevents filesystem recursion deadlocks since module_mutex can be held during filesystem operations) at all four allocation sites in p_kmod_hash(). This allows the allocator to reclaim pages by sleeping, eliminating the failure under memory pressure.

### How Has This Been Tested?

it was tested with high memory pressure environment which is mentioned in #487 
